### PR TITLE
setup all multiple causes logic

### DIFF
--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -1,5 +1,7 @@
 import OBR from "@owlbear-rodeo/sdk";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { isArray, mergeWith } from "lodash";
+
 
 import { AppContext } from "./AppContext";
 import { ID } from "./constants";
@@ -8,6 +10,8 @@ import type {
   AppContextProps,
   AppProviderProps,
   CausalityToken,
+  Causality,
+  CauseOperator,
   CausalityTokenMetaData,
   CollisionOptionsDialogConfig,
   EffectDialogConfig,
@@ -15,6 +19,7 @@ import type {
 
 export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   const [tokens, setTokens] = useState<CausalityToken[]>([]);
+  const [causalities, setCausalities] = useState<Causality[]>([]);
   const collisionTokensRef = useRef<CausalityToken[]>([]);
   const [effectDialog, setEffectDialog] = useState<EffectDialogConfig>({
     open: false,
@@ -49,6 +54,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   useEffect(() => {
     const onItemsChange = async () => {
       OBR.scene.items.onChange(async (items) => {
+        let collisionTokens: CausalityToken[] = [];
         const activeToolMode = await OBR.tool.getActiveToolMode();
 
         const causalityTokens = items.filter((item) => {
@@ -62,60 +68,108 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
             return true;
           }
         }) as CausalityToken[];
-        let collisionTokens: CausalityToken[] = [];
-        for (let i = 0; i < causalityTokens.length; i++) {
-          const cToken = causalityTokens[i];
-          const itemMetadata = cToken.metadata as CausalityTokenMetaData;
-          const causalityMetaData = itemMetadata[ID];
-          const causalities = causalityMetaData.causalities;
-          if (causalities && causalities.length > 0) {
-            for (let k = 0; k < causalities.length; k++) {
-              const causality = causalities[k];
-              const cause = causality.cause;
-              if (cause) {
-                if (cause.trigger && cause.status === "Pending") {
-                  switch (cause.trigger) {
-                    case "appears": {
-                      if (cToken.visible === true) {
-                        setTimeout(() => {
-                          return triggerEffectTokens(causality.id);
-                        }, Number(cause.delay));
-                      }
-                      break;
+
+        const causalitiesDeduper: { [id: string]: Causality } = {};
+        const clonedCausalityTokens = structuredClone(causalityTokens);
+
+        for (const token of clonedCausalityTokens) {
+          const tokenCausalities = token.metadata[ID].causalities;
+          if (tokenCausalities && tokenCausalities.length > 0) {
+            tokenCausalities.forEach((tokenCausality) => {
+              if (causalitiesDeduper[tokenCausality.id]) {
+                causalitiesDeduper[tokenCausality.id] = mergeWith(
+                  causalitiesDeduper[tokenCausality.id],
+                  tokenCausality,
+                  (objValue, srcValue) => {
+                    if (isArray(objValue)) {
+                      return objValue.concat(srcValue);
                     }
-                    case "disappears": {
-                      if (cToken.visible === false) {
-                        setTimeout(() => {
-                          return triggerEffectTokens(causality.id);
-                        }, Number(cause.delay));
-                      }
-                      break;
-                    }
-                    case "collision": {
-                      if (cause.isCollided) {
-                        setTimeout(() => {
-                          return triggerEffectTokens(
-                            causality.id,
-                            cause.instigatorEffects,
-                          );
-                        }, Number(cause.delay));
-                      }
-                      collisionTokens.push(cToken);
-                      break;
-                    }
+                  },
+                );
+              } else {
+                causalitiesDeduper[tokenCausality.id] = tokenCausality;
+              }
+            });
+          }
+        }
+
+        const causalities = Object.values(causalitiesDeduper);
+        setCausalities(causalities);
+
+        for (const causality of causalities) {
+          const causes = (causality.causes || []).sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? -1 : 1);
+
+          const causeConditionArray: [boolean, CauseOperator | undefined][] = causes.map((cause) => {
+            const tokenTiedToCause = causalityTokens.find((token) => token.id === cause.tokenId);
+            if (tokenTiedToCause && cause.trigger && cause.status === "Pending") {
+              switch (cause.trigger) {
+                case "appears": {
+                  if (tokenTiedToCause.visible === true) {
+                    return [true, cause.operator];
                   }
+                  break;
+                }
+                case "disappears": {
+                  if (tokenTiedToCause.visible === false) {
+                    return [true, cause.operator];
+                  }
+                  break;
+                }
+                case "collision": {
+                  if (!cause.isCollided) {
+                    collisionTokens.push(tokenTiedToCause);
+                  } else if (cause.isCollided) {
+                    return [true, cause.operator];
+                  }
+                  break;
+                }
+                default: {
+                  return [false, cause.operator];
                 }
               }
             }
-          }
+            return [false, cause.operator];
+          });
 
+          const areCauseConditionsMet = (causeConditionArray: [boolean, CauseOperator | undefined][]) => {
+            let areConditionsMet = causeConditionArray?.[0]?.[0];
+
+            for (let i = 1; i < causeConditionArray.length; i++) {
+              const [isConditionMet, operator] = causeConditionArray[i];
+              if (operator === "AND") {
+                areConditionsMet = areConditionsMet && isConditionMet;
+              } else if (operator === "OR") {
+                areConditionsMet = areConditionsMet || isConditionMet;
+              }
+            }
+
+            return areConditionsMet;
+          };
+
+          if (areCauseConditionsMet(causeConditionArray)) {
+            if (causes[0].instigatorEffects && causes[0].instigatorEffects.length > 0) {
+              setTimeout(() => {
+                return triggerEffectTokens(
+                  causality.id,
+                  causes[0].instigatorEffects,
+                );
+              }, Number(causes[0].delay));
+            } else {
+              setTimeout(() => {
+                return triggerEffectTokens(causality.id);
+              }, Number(causes[0].delay));
+            }
+          }
+        }
+
+        for (const token of causalityTokens) {
           // Logic for checking collisions if using the default move tool
           if (activeToolMode === "rodeo.owlbear.tool-mode/move") {
             const tokensToCheck = collisionTokensRef.current;
             for (const tokenToCheck of tokensToCheck) {
               if (
-                cToken.id !== tokenToCheck.id &&
-                hasCollisionOccured(cToken, tokenToCheck)
+                token.id !== tokenToCheck.id &&
+                hasCollisionOccured(token, tokenToCheck)
               ) {
                 await OBR.scene.items.updateItems(
                   (item) => {
@@ -129,27 +183,29 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
                     const causalities = itemMetaData.causalities;
                     if (causalities && causalities.length > 0) {
                       for (let causality of causalities) {
-                        const cause = causality.cause;
-                        if (cause) {
-                          if (cause.isCollided === false) {
-                            // Check if there's a scope of only 1 specific token that should be triggering the collision.
-                            if (
-                              cause.tokenToTriggerCollision?.id &&
-                              cause.tokenToTriggerCollision.id !== cToken.id
-                            ) {
-                              return;
-                            }
-                            // Successful Collision!
-                            cause.isCollided = true;
-                            const instigatorEffects = cause.instigatorEffects;
-                            if (
-                              instigatorEffects &&
-                              instigatorEffects.length > 0
-                            ) {
-                              for (const ie of instigatorEffects) {
-                                const oldTokenID = ie.tokenId;
-                                ie.originalCauseTokenId = oldTokenID;
-                                ie.tokenId = cToken.id;
+                        const causes = causality.causes || [];
+                        for (const cause of causes) {
+                          if (cause) {
+                            if (cause.isCollided === false) {
+                              // Check if there's a scope of only 1 specific token that should be triggering the collision.
+                              if (
+                                cause.tokenToTriggerCollision?.id &&
+                                cause.tokenToTriggerCollision.id !== token.id
+                              ) {
+                                return;
+                              }
+                              // Successful Collision!
+                              cause.isCollided = true;
+                              const instigatorEffects = cause.instigatorEffects;
+                              if (
+                                instigatorEffects &&
+                                instigatorEffects.length > 0
+                              ) {
+                                for (const ie of instigatorEffects) {
+                                  const oldTokenID = ie.tokenId;
+                                  ie.originalCauseTokenId = oldTokenID;
+                                  ie.tokenId = token.id;
+                                }
                               }
                             }
                           }
@@ -174,6 +230,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
 
   const store: AppContextProps = {
     tokens,
+    causalities,
     collisionTokensRef,
     effectDialog,
     updateEffectDialog,

--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -53,7 +53,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
   useEffect(() => {
     const onItemsChange = async () => {
       OBR.scene.items.onChange(async (items) => {
-        let collisionTokens: CausalityToken[] = [];
+        const collisionTokens: CausalityToken[] = [];
         const activeToolMode = await OBR.tool.getActiveToolMode();
 
         const causalityTokens = items.filter((item) => {
@@ -195,7 +195,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
                     const itemMetaData = itemToUpdate.metadata[ID];
                     const causalities = itemMetaData.causalities;
                     if (causalities && causalities.length > 0) {
-                      for (let causality of causalities) {
+                      for (const causality of causalities) {
                         const causes = causality.causes || [];
                         for (const cause of causes) {
                           if (cause) {

--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -1,7 +1,6 @@
 import OBR from "@owlbear-rodeo/sdk";
-import { useCallback, useEffect, useRef, useState } from "react";
 import { isArray, mergeWith } from "lodash";
-
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { AppContext } from "./AppContext";
 import { ID } from "./constants";
@@ -9,10 +8,10 @@ import { hasCollisionOccured, triggerEffectTokens } from "./functions";
 import type {
   AppContextProps,
   AppProviderProps,
-  CausalityToken,
   Causality,
-  CauseOperator,
+  CausalityToken,
   CausalityTokenMetaData,
+  CauseOperator,
   CollisionOptionsDialogConfig,
   EffectDialogConfig,
 } from "./types";
@@ -97,41 +96,52 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
         setCausalities(causalities);
 
         for (const causality of causalities) {
-          const causes = (causality.causes || []).sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? -1 : 1);
+          const causes = (causality.causes || []).sort((a, b) =>
+            new Date(a.timestamp) < new Date(b.timestamp) ? -1 : 1,
+          );
 
-          const causeConditionArray: [boolean, CauseOperator | undefined][] = causes.map((cause) => {
-            const tokenTiedToCause = causalityTokens.find((token) => token.id === cause.tokenId);
-            if (tokenTiedToCause && cause.trigger && cause.status === "Pending") {
-              switch (cause.trigger) {
-                case "appears": {
-                  if (tokenTiedToCause.visible === true) {
-                    return [true, cause.operator];
+          const causeConditionArray: [boolean, CauseOperator | undefined][] =
+            causes.map((cause) => {
+              const tokenTiedToCause = causalityTokens.find(
+                (token) => token.id === cause.tokenId,
+              );
+              if (
+                tokenTiedToCause &&
+                cause.trigger &&
+                cause.status === "Pending"
+              ) {
+                switch (cause.trigger) {
+                  case "appears": {
+                    if (tokenTiedToCause.visible === true) {
+                      return [true, cause.operator];
+                    }
+                    break;
                   }
-                  break;
-                }
-                case "disappears": {
-                  if (tokenTiedToCause.visible === false) {
-                    return [true, cause.operator];
+                  case "disappears": {
+                    if (tokenTiedToCause.visible === false) {
+                      return [true, cause.operator];
+                    }
+                    break;
                   }
-                  break;
-                }
-                case "collision": {
-                  if (!cause.isCollided) {
-                    collisionTokens.push(tokenTiedToCause);
-                  } else if (cause.isCollided) {
-                    return [true, cause.operator];
+                  case "collision": {
+                    if (!cause.isCollided) {
+                      collisionTokens.push(tokenTiedToCause);
+                    } else if (cause.isCollided) {
+                      return [true, cause.operator];
+                    }
+                    break;
                   }
-                  break;
-                }
-                default: {
-                  return [false, cause.operator];
+                  default: {
+                    return [false, cause.operator];
+                  }
                 }
               }
-            }
-            return [false, cause.operator];
-          });
+              return [false, cause.operator];
+            });
 
-          const areCauseConditionsMet = (causeConditionArray: [boolean, CauseOperator | undefined][]) => {
+          const areCauseConditionsMet = (
+            causeConditionArray: [boolean, CauseOperator | undefined][],
+          ) => {
             let areConditionsMet = causeConditionArray?.[0]?.[0];
 
             for (let i = 1; i < causeConditionArray.length; i++) {
@@ -147,7 +157,10 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
           };
 
           if (areCauseConditionsMet(causeConditionArray)) {
-            if (causes[0].instigatorEffects && causes[0].instigatorEffects.length > 0) {
+            if (
+              causes[0].instigatorEffects &&
+              causes[0].instigatorEffects.length > 0
+            ) {
               setTimeout(() => {
                 return triggerEffectTokens(
                   causality.id,

--- a/src/components/BroadcastInput.tsx
+++ b/src/components/BroadcastInput.tsx
@@ -56,6 +56,7 @@ export const BroadcastInput = ({ causality, effect }: BroadcastInputProps) => {
       JSON.parse(newValue);
       setDataError(null);
       debouncedUpdateData(newValue);
+      // eslint-disable-next-line
     } catch (err: any) {
       setDataError(err.message);
     }

--- a/src/components/Causalities.module.css
+++ b/src/components/Causalities.module.css
@@ -7,15 +7,7 @@
   height: 17rem;
   overflow-y: scroll;
   scrollbar-gutter: stable;
-}
-
-.causalities-title {
-  position: absolute;
-  top: 295px;
-  padding: 0 0.25rem;
-  width: fit-content;
-  margin-block-end: 0;
-  background-color: #242424;
+  position: relative;
 }
 
 .causalities-token-area {
@@ -69,53 +61,6 @@
   display: flex;
 }
 
-.causality-cause {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  height: fit-content;
-  flex: 1;
-  padding: 0.5rem;
-  border-radius: 10px;
-  background-color: #555555;
-  box-shadow: 3px 3px 2px 0px rgba(0, 0, 0, 0.2);
-}
-
-.causality-cause-when {
-  font-size: 18px;
-  font-weight: 600;
-  margin-bottom: 0.5rem;
-}
-
-.causality-cause-info {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.causality-cause-image {
-  width: 50px;
-  height: 50px;
-  margin-right: 0.5rem;
-}
-
-.causality-cause-name {
-  font-size: 16px;
-  font-weight: 600;
-}
-
-.causality-cause-trigger-settings {
-  display: block;
-  width: 100%;
-}
-
-.causality-cause-trigger-settings select {
-  width: 100%;
-  cursor: pointer;
-}
-
 .causality-footer-area {
   display: flex;
   justify-content: space-between;
@@ -150,32 +95,4 @@
   display: inline;
   font-size: 12px;
   margin-left: 0.25rem;
-}
-
-.collision-edit-area {
-  display: flex;
-  align-items: center;
-  margin-top: 0.25rem;
-}
-
-.collision-edit-buttton {
-  border: 1px solid #8447ff;
-  background-color: #4c396e;
-  border-radius: 5px;
-  cursor: pointer;
-  box-shadow: 3px 3px 2px 0px rgba(0, 0, 0, 0.4);
-  font-weight: 600;
-  margin-right: 0.5rem;
-}
-
-.collision-edit-area-token-text img {
-  width: 40px;
-  height: 40px;
-  margin-right: 0.25rem;
-}
-
-.collision-edit-area-token-text {
-  display: flex;
-  align-items: center;
-  font-size: 14px;
 }

--- a/src/components/Causalities.tsx
+++ b/src/components/Causalities.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from "motion/react";
 import { memo } from "react";
 import ShortUniqueId from "short-unique-id";
+
 import fire from "../assets/fire.svg";
 import reset from "../assets/reset.svg";
 import target from "../assets/target.svg";
@@ -12,7 +13,7 @@ import {
   updateCauseTokenData,
 } from "../functions";
 import { useAppStore } from "../functions/hooks";
-import type { CauseTrigger, CausalityStatus, CausalitiesProps } from "../types";
+import type { CausalitiesProps, CausalityStatus, CauseTrigger } from "../types";
 import styles from "./Causalities.module.css";
 import { Cause } from "./Cause";
 import { Effect } from "./Effect";
@@ -30,17 +31,25 @@ export const Causalities = memo(({ height }: CausalitiesProps) => {
         })
         .map((causality) => {
           const effectsIDSet = new Set();
-          const causes = (causality.causes || []).sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? -1 : 1);
-          const instigatorEffects = (causes || []).flatMap((cause) => cause.instigatorEffects || []);
+          const causes = (causality.causes || []).sort((a, b) =>
+            new Date(a.timestamp) < new Date(b.timestamp) ? -1 : 1,
+          );
+          const instigatorEffects = (causes || []).flatMap(
+            (cause) => cause.instigatorEffects || [],
+          );
           const effects = causality.effects;
           const allEffects =
             instigatorEffects &&
-              instigatorEffects.length > 0 &&
-              causes?.some((cause) => cause.trigger === "collision")
+            instigatorEffects.length > 0 &&
+            causes?.some((cause) => cause.trigger === "collision")
               ? [...(effects || []), ...instigatorEffects]
               : effects || [];
 
-          const causalityStatus: CausalityStatus = causality.causes?.every((cause) => cause.status === "Complete") ? "Complete" : "Pending";
+          const causalityStatus: CausalityStatus = causality.causes?.every(
+            (cause) => cause.status === "Complete",
+          )
+            ? "Complete"
+            : "Pending";
 
           return (
             <motion.div
@@ -65,9 +74,7 @@ export const Causalities = memo(({ height }: CausalitiesProps) => {
                 />
                 <motion.p layout className={styles["causality-status"]}>
                   Status:{" "}
-                  <span data-status={causalityStatus}>
-                    {causalityStatus}
-                  </span>
+                  <span data-status={causalityStatus}>{causalityStatus}</span>
                 </motion.p>
                 <motion.img
                   layout
@@ -83,15 +90,16 @@ export const Causalities = memo(({ height }: CausalitiesProps) => {
                 {/* CAUSE TOKEN AREA */}
                 <Droppable id={`${causality.id}-causes`}>
                   <>
-                    {causes && causes.length > 0 && causes.map((cause, index) => (
-                      <Cause
-                        cause={cause}
-                        causality={causality}
-                        key={cause.causeId}
-                        index={index}
-                      />
-                    )
-                    )}
+                    {causes &&
+                      causes.length > 0 &&
+                      causes.map((cause, index) => (
+                        <Cause
+                          cause={cause}
+                          causality={causality}
+                          key={cause.causeId}
+                          index={index}
+                        />
+                      ))}
                   </>
                 </Droppable>
                 {/* EFFECT TOKEN AREA */}
@@ -189,9 +197,7 @@ export const Causalities = memo(({ height }: CausalitiesProps) => {
                         }
                       }}
                       value={causes[0]?.delay || "0"}
-                      disabled={
-                        causalityStatus === "Complete" ? true : false
-                      }
+                      disabled={causalityStatus === "Complete" ? true : false}
                     >
                       {[
                         ["0", "0s"],
@@ -236,7 +242,10 @@ export const Causalities = memo(({ height }: CausalitiesProps) => {
   return (
     <Droppable id={DROP_ZONE_ID}>
       <section className={styles["causalities-section"]}>
-        <div style={{ height: height }} className={styles["causalities-scroll-area"]}>
+        <div
+          style={{ height: height }}
+          className={styles["causalities-scroll-area"]}
+        >
           <div className={styles["causalities-token-area"]}>
             <AnimatePresence>{populateCausalities()}</AnimatePresence>
           </div>

--- a/src/components/Causalities.tsx
+++ b/src/components/Causalities.tsx
@@ -1,78 +1,46 @@
-import { isArray, mergeWith } from "lodash";
 import { AnimatePresence, motion } from "motion/react";
 import { memo } from "react";
 import ShortUniqueId from "short-unique-id";
-
 import fire from "../assets/fire.svg";
 import reset from "../assets/reset.svg";
 import target from "../assets/target.svg";
 import timer from "../assets/timer.svg";
-import { DROP_ZONE_ID, ID } from "../constants";
+import { DROP_ZONE_ID } from "../constants";
 import {
   handleRemoveCausality,
   handleResetCausality,
   updateCauseTokenData,
 } from "../functions";
 import { useAppStore } from "../functions/hooks";
-import type { Causality, Cause, CauseTrigger } from "../types";
+import type { CauseTrigger, CausalityStatus, CausalitiesProps } from "../types";
 import styles from "./Causalities.module.css";
+import { Cause } from "./Cause";
 import { Effect } from "./Effect";
 import { Droppable } from "./dnd/Droppable";
 
 const { randomUUID } = new ShortUniqueId({ length: 8 });
 
-export const Causalities = memo(() => {
-  const { tokens, updateCollisionOptionsDialog } = useAppStore();
-
-  const handleShowCollisionOptionsDialog = (cause: Cause) => {
-    updateCollisionOptionsDialog({
-      open: true,
-      cause,
-    });
-  };
-
+export const Causalities = memo(({ height }: CausalitiesProps) => {
+  const { causalities } = useAppStore();
   const populateCausalities = () => {
-    const causalities: { [id: string]: Causality } = {};
-
-    tokens.forEach((token) => {
-      const tokenCausalities = token.metadata[ID].causalities;
-
-      if (tokenCausalities && tokenCausalities.length > 0) {
-        tokenCausalities.forEach((tokenCausality) => {
-          if (causalities[tokenCausality.id]) {
-            causalities[tokenCausality.id] = mergeWith(
-              causalities[tokenCausality.id],
-              tokenCausality,
-              (objValue, srcValue) => {
-                if (isArray(objValue)) {
-                  return objValue.concat(srcValue);
-                }
-              },
-            );
-          } else {
-            causalities[tokenCausality.id] = tokenCausality;
-          }
-        });
-      }
-    });
-
-    const causalityDataArray = Object.values(causalities);
-    return causalityDataArray.length > 0 ? (
-      causalityDataArray
+    return causalities.length > 0 ? (
+      causalities
         .sort((a, b) => {
           return new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1;
         })
         .map((causality) => {
           const effectsIDSet = new Set();
-          const cause = causality.cause;
-          const instigatorEffects = cause?.instigatorEffects;
+          const causes = (causality.causes || []).sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? -1 : 1);
+          const instigatorEffects = (causes || []).flatMap((cause) => cause.instigatorEffects || []);
           const effects = causality.effects;
           const allEffects =
             instigatorEffects &&
-            instigatorEffects.length > 0 &&
-            cause.trigger === "collision"
+              instigatorEffects.length > 0 &&
+              causes?.some((cause) => cause.trigger === "collision")
               ? [...(effects || []), ...instigatorEffects]
-              : effects;
+              : effects || [];
+
+          const causalityStatus: CausalityStatus = causality.causes?.every((cause) => cause.status === "Complete") ? "Complete" : "Pending";
 
           return (
             <motion.div
@@ -83,7 +51,7 @@ export const Causalities = memo(() => {
               exit={{ opacity: 0, y: 10 }}
               transition={{ duration: 0.25 }}
               layout
-              data-status={causality.cause?.status}
+              data-status={causalityStatus}
             >
               <motion.div layout className={styles["causality-title-area"]}>
                 <motion.p layout>Causes</motion.p>
@@ -97,8 +65,8 @@ export const Causalities = memo(() => {
                 />
                 <motion.p layout className={styles["causality-status"]}>
                   Status:{" "}
-                  <span data-status={causality.cause?.status}>
-                    {causality.cause?.status}
+                  <span data-status={causalityStatus}>
+                    {causalityStatus}
                   </span>
                 </motion.p>
                 <motion.img
@@ -113,101 +81,21 @@ export const Causalities = memo(() => {
               </motion.div>
               <motion.div className={styles["causality-cause-effect-area"]}>
                 {/* CAUSE TOKEN AREA */}
-                {cause && (
-                  <motion.div
-                    className={styles["causality-cause"]}
-                    initial={{ opacity: 0, y: -10 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    exit={{ opacity: 0, y: 10 }}
-                    transition={{ duration: 0.25 }}
-                    layout
-                  >
-                    <motion.p layout className={styles["causality-cause-when"]}>
-                      When:
-                    </motion.p>
-                    <motion.div
-                      layout
-                      className={styles["causality-cause-info"]}
-                    >
-                      <motion.img
-                        layout
-                        className={styles["causality-cause-image"]}
-                        src={cause?.imageUrl}
-                        alt={cause?.name}
+                <Droppable id={`${causality.id}-causes`}>
+                  <>
+                    {causes && causes.length > 0 && causes.map((cause, index) => (
+                      <Cause
+                        cause={cause}
+                        causality={causality}
+                        key={cause.causeId}
+                        index={index}
                       />
-                      <motion.p
-                        layout
-                        className={styles["causality-cause-name"]}
-                      >
-                        {cause.name}
-                      </motion.p>
-                    </motion.div>
-                    <motion.div
-                      layout
-                      className={styles["causality-cause-trigger-settings"]}
-                    >
-                      <motion.select
-                        layout
-                        onChange={(event) => {
-                          return updateCauseTokenData(
-                            causality.id,
-                            cause.tokenId,
-                            "trigger",
-                            event.target.value as CauseTrigger,
-                          );
-                        }}
-                        name="cause-triggers"
-                        value={cause.trigger || ""}
-                        disabled={cause?.status === "Complete" ? true : false}
-                      >
-                        <option value="">-- Please choose an option --</option>
-                        <option value="collision">Is Collided Into</option>
-                        <option value="appears">Appears</option>
-                        <option value="disappears">Disappears</option>
-                      </motion.select>
-                      {cause.trigger === "collision" && (
-                        <div className={styles["collision-edit-area"]}>
-                          <button
-                            className={styles["collision-edit-buttton"]}
-                            onClick={() =>
-                              handleShowCollisionOptionsDialog(cause)
-                            }
-                            title={
-                              "Click here to assign a specific token to trigger the collision"
-                            }
-                            disabled={
-                              cause.status === "Complete" ? true : false
-                            }
-                          >
-                            By...
-                          </button>
-
-                          {cause.tokenToTriggerCollision?.name &&
-                          cause.tokenToTriggerCollision?.imageUrl ? (
-                            <p
-                              className={
-                                styles["collision-edit-area-token-text"]
-                              }
-                            >
-                              <img
-                                src={cause.tokenToTriggerCollision.imageUrl}
-                                alt={cause.tokenToTriggerCollision.name}
-                              />
-                              {cause.tokenToTriggerCollision.name}
-                              {cause.tokenToTriggerCollision.label
-                                ? ` / ${cause.tokenToTriggerCollision.label}`
-                                : ""}
-                            </p>
-                          ) : (
-                            <p>...any token</p>
-                          )}
-                        </div>
-                      )}
-                    </motion.div>
-                  </motion.div>
-                )}
+                    )
+                    )}
+                  </>
+                </Droppable>
                 {/* EFFECT TOKEN AREA */}
-                <Droppable id={causality.id}>
+                <Droppable id={`${causality.id}-effects`}>
                   {allEffects && allEffects.length > 0 ? (
                     <>
                       {allEffects.map((effect) => {
@@ -238,7 +126,7 @@ export const Causalities = memo(() => {
                   )}
 
                   <>
-                    {cause?.trigger === "collision" && (
+                    {causes?.some((cause) => cause.trigger === "collision") && (
                       <div>
                         <img
                           className={styles["causality-triggering-token-icon"]}
@@ -248,10 +136,10 @@ export const Causalities = memo(() => {
                           onClick={() => {
                             return updateCauseTokenData(
                               causality.id,
-                              cause.tokenId,
+                              causes[0].tokenId,
                               "instigatorEffects",
                               [
-                                ...(cause.instigatorEffects || []),
+                                ...(causes[0].instigatorEffects || []),
                                 {
                                   name: "The Triggering Token",
                                   label: "",
@@ -260,10 +148,10 @@ export const Causalities = memo(() => {
                                   action: "",
                                   isInstigator: true,
                                   causalityId: causality.id,
-                                  // Set the tokenID to the cause token, just until the collision occurs.
+                                  // Set the tokenID to the first cause token, just until the collision occurs.
                                   // It will then be updated to the token id for the token that actually
                                   // instigated a collision.
-                                  tokenId: cause.tokenId,
+                                  tokenId: causes[0].tokenId,
                                 },
                               ],
                             );
@@ -291,18 +179,18 @@ export const Causalities = memo(() => {
                       name="time-delay"
                       title="Set a time delay"
                       onChange={(event) => {
-                        if (causality.cause) {
+                        if (causes[0]) {
                           return updateCauseTokenData(
                             causality.id,
-                            causality.cause.tokenId,
+                            causes[0].tokenId,
                             "delay",
                             event.target.value as CauseTrigger,
                           );
                         }
                       }}
-                      value={causality.cause?.delay}
+                      value={causes[0]?.delay || "0"}
                       disabled={
-                        causality.cause?.status === "Complete" ? true : false
+                        causalityStatus === "Complete" ? true : false
                       }
                     >
                       {[
@@ -348,8 +236,7 @@ export const Causalities = memo(() => {
   return (
     <Droppable id={DROP_ZONE_ID}>
       <section className={styles["causalities-section"]}>
-        <div className={styles["causalities-scroll-area"]}>
-          <h2 className={styles["causalities-title"]}>Causalities</h2>
+        <div style={{ height: height }} className={styles["causalities-scroll-area"]}>
           <div className={styles["causalities-token-area"]}>
             <AnimatePresence>{populateCausalities()}</AnimatePresence>
           </div>

--- a/src/components/CausalityLogManager.tsx
+++ b/src/components/CausalityLogManager.tsx
@@ -63,7 +63,8 @@ export const CausalityLogManager = () => {
                         src={effect.imageUrl}
                         alt={effect.name}
                       />{" "}
-                      <strong>{effect.name}</strong>&nbsp;<em>{actionMap[effect.action || "default"]}</em>.&nbsp;
+                      <strong>{effect.name}</strong>&nbsp;
+                      <em>{actionMap[effect.action || "default"]}</em>.&nbsp;
                     </motion.p>
                   ));
                 })}

--- a/src/components/CausalityLogManager.tsx
+++ b/src/components/CausalityLogManager.tsx
@@ -14,8 +14,8 @@ export const CausalityLogManager = () => {
       OBR.broadcast.onMessage(`${ID}/log`, (data) => {
         const newLogs = Object.values(data.data || []) as CausalityLog[];
         for (const log of newLogs) {
-          const { cause, effects } = log;
-          if (cause && effects && effects.length > 0) {
+          const { effects } = log;
+          if (effects && effects.length > 0) {
             setLogs((prev) => {
               return [log, ...prev];
             });
@@ -29,20 +29,13 @@ export const CausalityLogManager = () => {
     });
   }, []);
 
-  const triggerMap = {
-    collision: "was collided into",
-    appears: "appeared",
-    disappears: "disappeared",
-    default: "triggered",
-  };
-
   const actionMap = {
-    lock: "locking",
-    unlock: "unlocking",
-    appear: "appearing",
-    disappear: "disappearing",
-    broadcast: "broadcasting",
-    default: "triggering",
+    lock: "locked",
+    unlock: "unlocked",
+    appear: "appeared",
+    disappear: "disappeared",
+    broadcast: "broadcasted",
+    default: "triggerred",
   };
 
   return (
@@ -54,7 +47,7 @@ export const CausalityLogManager = () => {
             {logs && logs.length > 0 ? (
               <>
                 {logs.map((log) => {
-                  const { cause, effects, logID } = log;
+                  const { effects, logID } = log;
                   return effects.map((effect) => (
                     <motion.p
                       layout="position"
@@ -66,19 +59,11 @@ export const CausalityLogManager = () => {
                       transition={{ duration: 0.25 }}
                     >
                       <img
-                        className={styles["log-content-cause-img"]}
-                        src={cause.imageUrl}
-                        alt={cause.name}
-                      />
-                      <strong>{cause.name}</strong>&nbsp;
-                      <em>{triggerMap[cause.trigger || "default"]}</em>.{" "}
-                      <img
                         className={styles["log-content-effect-img"]}
                         src={effect.imageUrl}
                         alt={effect.name}
                       />{" "}
-                      <strong>{effect.name}</strong>&nbsp;responded by&nbsp;
-                      <em>{actionMap[effect.action || "default"]}</em>.
+                      <strong>{effect.name}</strong>&nbsp;<em>{actionMap[effect.action || "default"]}</em>.&nbsp;
                     </motion.p>
                   ));
                 })}

--- a/src/components/CausalityManager.module.css
+++ b/src/components/CausalityManager.module.css
@@ -1,0 +1,9 @@
+.causality-manager-resize::after {
+  content: "Causalities";
+  font-size: 24px;
+  font-weight: 700;
+  background-color: #242424;
+  padding: 0 0.25rem;
+  position: relative;
+  left: -261px;
+}

--- a/src/components/CausalityManager.tsx
+++ b/src/components/CausalityManager.tsx
@@ -13,10 +13,44 @@ import type { CausalityToken } from "../types";
 import { Causalities } from "./Causalities";
 import { Token } from "./Token";
 import { TokenPool } from "./TokenPool";
+import styles from "./CausalityManager.module.css";
 
 const { randomUUID } = new ShortUniqueId({ length: 8 });
 
+const MIN_PANE = 0;
+
 export const CausalityManager = () => {
+  const [topH,    setTopH]    = useState(150);
+  const [bottomH, setBotH]    = useState(280);
+
+  const startResize = (e: React.PointerEvent<HTMLDivElement>) => {
+    // capture starting geometry
+    const startY   = e.clientY;
+    const startTop = topH;
+    const startBot = bottomH;
+
+    const onMove = (ev: PointerEvent) => {
+      const delta     = ev.clientY - startY;
+      let   newTop    = startTop + delta;
+      let   newBot    = startBot - delta;
+
+      // clamp so neither pane disappears
+      if (newTop < MIN_PANE)  { newTop = MIN_PANE;  newBot = startTop + startBot - newTop; }
+      if (newBot < MIN_PANE)  { newBot = MIN_PANE;  newTop = startTop + startBot - newBot; }
+
+      setTopH(newTop);
+      setBotH(newBot);
+    };
+
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+
   const [activeToken, setActiveToken] = useState<CausalityToken | null>(null);
 
   const handleDragStart = (event: DragStartEvent) => {
@@ -34,32 +68,40 @@ export const CausalityManager = () => {
         },
         (items) => {
           const itemToUpdate = items[0] as CausalityToken;
-          const uniqueKey = randomUUID();
+          const uniqueCausalityId = randomUUID();
+          const uniqueCauseId = randomUUID();
 
           if (!itemToUpdate.metadata[ID].causalities) {
             itemToUpdate.metadata[ID].causalities = [];
           }
 
+          const timestamp = new Date().toISOString();
+
           itemToUpdate.metadata[ID].causalities.unshift({
-            id: uniqueKey,
-            timestamp: new Date().toISOString(),
-            cause: {
-              status: "Pending",
-              delay: "0",
-              isCollided: false,
-              tokenId: itemToUpdate.id,
-              causalityId: uniqueKey,
-              name: itemToUpdate.name,
-              label: itemToUpdate.text?.plainText,
-              imageUrl: itemToUpdate.image.url,
-              trigger: "",
-            },
+            id: uniqueCausalityId,
+            tokenId: itemToUpdate.id,
+            timestamp,
+            causes: [
+              {
+                status: "Pending",
+                delay: "0",
+                isCollided: false,
+                tokenId: itemToUpdate.id,
+                causalityId: uniqueCausalityId,
+                name: itemToUpdate.name,
+                label: itemToUpdate.text?.plainText,
+                imageUrl: itemToUpdate.image.url,
+                trigger: "",
+                causeId: uniqueCauseId,
+                timestamp,
+              }
+            ],
           });
         },
       );
-    } else if (event.over?.id) {
+    } else if (((event.over?.id as string) || "").includes("effects")) {
       // Token was dragged into an effect token area
-      const causalityId = event.over.id as string;
+      const causalityId = (event.over?.id as string).split("-effects")[0];
       OBR.scene.items.updateItems(
         (item) => {
           return item.id === currentToken.id;
@@ -94,6 +136,7 @@ export const CausalityManager = () => {
           } else {
             itemToUpdate.metadata[ID].causalities.push({
               id: causalityId,
+              tokenId: itemToUpdate.id,
               timestamp: new Date().toISOString(),
               effects: [
                 {
@@ -110,13 +153,92 @@ export const CausalityManager = () => {
           }
         },
       );
+    } else if (((event.over?.id as string) || "").includes("causes")) {
+      const causalityId = (event.over?.id as string).split("-causes")[0];
+      OBR.scene.items.updateItems(
+        (item) => {
+          return item.id === currentToken.id;
+        },
+        (items) => {
+          const itemToUpdate = items[0] as CausalityToken;
+          if (!itemToUpdate.metadata[ID].causalities) {
+            itemToUpdate.metadata[ID].causalities = [];
+          }
+
+          const alreadyPresentCausality = itemToUpdate.metadata[
+            ID
+          ].causalities.find((causality) => {
+            return causality.id === causalityId;
+          });
+
+          const timestamp = new Date().toISOString();
+          const uniqueCauseId = randomUUID();
+
+          if (alreadyPresentCausality) {
+            if (!alreadyPresentCausality.causes) {
+              alreadyPresentCausality.causes = [];
+            }
+            alreadyPresentCausality.causes.push(
+              {
+                status: "Pending",
+                isCollided: false,
+                tokenId: itemToUpdate.id,
+                causalityId: alreadyPresentCausality.id,
+                name: itemToUpdate.name,
+                label: itemToUpdate.text?.plainText,
+                imageUrl: itemToUpdate.image.url,
+                trigger: "",
+                causeId: uniqueCauseId,
+                timestamp,
+                operator: "AND",
+              }
+            );
+          } else {
+            itemToUpdate.metadata[ID].causalities.push({
+              id: causalityId,
+              tokenId: itemToUpdate.id,
+              timestamp,
+              causes: [
+                {
+                  status: "Pending",
+                  isCollided: false,
+                  tokenId: itemToUpdate.id,
+                  causalityId: causalityId,
+                  name: itemToUpdate.name,
+                  label: itemToUpdate.text?.plainText,
+                  imageUrl: itemToUpdate.image.url,
+                  trigger: "",
+                  causeId: uniqueCauseId,
+                  timestamp,
+                  operator: "AND",
+                },
+              ],
+            });
+          }
+        }
+      );
     }
   };
 
   return (
     <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-      <TokenPool />
-      <Causalities />
+        <TokenPool height={topH} />
+        
+        <div
+          className={styles["causality-manager-resize"]}
+          onPointerDown={startResize}
+          style={{
+            height: "6px",
+            borderRadius: "9999px",
+            width: "60px",
+            margin: "auto",
+            cursor: "row-resize",
+            background: "white",
+            transform: "translateY(-15px)"
+          }}
+        />
+
+        <Causalities height={bottomH} />
       <DragOverlay>
         {activeToken && <Token isOverlay={true} token={activeToken} />}
       </DragOverlay>

--- a/src/components/CausalityManager.tsx
+++ b/src/components/CausalityManager.tsx
@@ -11,32 +11,38 @@ import ShortUniqueId from "short-unique-id";
 import { DROP_ZONE_ID, ID } from "../constants";
 import type { CausalityToken } from "../types";
 import { Causalities } from "./Causalities";
+import styles from "./CausalityManager.module.css";
 import { Token } from "./Token";
 import { TokenPool } from "./TokenPool";
-import styles from "./CausalityManager.module.css";
 
 const { randomUUID } = new ShortUniqueId({ length: 8 });
 
 const MIN_PANE = 0;
 
 export const CausalityManager = () => {
-  const [topH,    setTopH]    = useState(150);
-  const [bottomH, setBotH]    = useState(280);
+  const [topH, setTopH] = useState(150);
+  const [bottomH, setBotH] = useState(280);
 
   const startResize = (e: React.PointerEvent<HTMLDivElement>) => {
     // capture starting geometry
-    const startY   = e.clientY;
+    const startY = e.clientY;
     const startTop = topH;
     const startBot = bottomH;
 
     const onMove = (ev: PointerEvent) => {
-      const delta     = ev.clientY - startY;
-      let   newTop    = startTop + delta;
-      let   newBot    = startBot - delta;
+      const delta = ev.clientY - startY;
+      let newTop = startTop + delta;
+      let newBot = startBot - delta;
 
       // clamp so neither pane disappears
-      if (newTop < MIN_PANE)  { newTop = MIN_PANE;  newBot = startTop + startBot - newTop; }
-      if (newBot < MIN_PANE)  { newBot = MIN_PANE;  newTop = startTop + startBot - newBot; }
+      if (newTop < MIN_PANE) {
+        newTop = MIN_PANE;
+        newBot = startTop + startBot - newTop;
+      }
+      if (newBot < MIN_PANE) {
+        newBot = MIN_PANE;
+        newTop = startTop + startBot - newBot;
+      }
 
       setTopH(newTop);
       setBotH(newBot);
@@ -94,7 +100,7 @@ export const CausalityManager = () => {
                 trigger: "",
                 causeId: uniqueCauseId,
                 timestamp,
-              }
+              },
             ],
           });
         },
@@ -178,21 +184,19 @@ export const CausalityManager = () => {
             if (!alreadyPresentCausality.causes) {
               alreadyPresentCausality.causes = [];
             }
-            alreadyPresentCausality.causes.push(
-              {
-                status: "Pending",
-                isCollided: false,
-                tokenId: itemToUpdate.id,
-                causalityId: alreadyPresentCausality.id,
-                name: itemToUpdate.name,
-                label: itemToUpdate.text?.plainText,
-                imageUrl: itemToUpdate.image.url,
-                trigger: "",
-                causeId: uniqueCauseId,
-                timestamp,
-                operator: "AND",
-              }
-            );
+            alreadyPresentCausality.causes.push({
+              status: "Pending",
+              isCollided: false,
+              tokenId: itemToUpdate.id,
+              causalityId: alreadyPresentCausality.id,
+              name: itemToUpdate.name,
+              label: itemToUpdate.text?.plainText,
+              imageUrl: itemToUpdate.image.url,
+              trigger: "",
+              causeId: uniqueCauseId,
+              timestamp,
+              operator: "AND",
+            });
           } else {
             itemToUpdate.metadata[ID].causalities.push({
               id: causalityId,
@@ -215,30 +219,30 @@ export const CausalityManager = () => {
               ],
             });
           }
-        }
+        },
       );
     }
   };
 
   return (
     <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-        <TokenPool height={topH} />
-        
-        <div
-          className={styles["causality-manager-resize"]}
-          onPointerDown={startResize}
-          style={{
-            height: "6px",
-            borderRadius: "9999px",
-            width: "60px",
-            margin: "auto",
-            cursor: "row-resize",
-            background: "white",
-            transform: "translateY(-15px)"
-          }}
-        />
+      <TokenPool height={topH} />
 
-        <Causalities height={bottomH} />
+      <div
+        className={styles["causality-manager-resize"]}
+        onPointerDown={startResize}
+        style={{
+          height: "6px",
+          borderRadius: "9999px",
+          width: "60px",
+          margin: "auto",
+          cursor: "row-resize",
+          background: "white",
+          transform: "translateY(-15px)",
+        }}
+      />
+
+      <Causalities height={bottomH} />
       <DragOverlay>
         {activeToken && <Token isOverlay={true} token={activeToken} />}
       </DragOverlay>

--- a/src/components/Cause.module.css
+++ b/src/components/Cause.module.css
@@ -54,7 +54,6 @@
   cursor: pointer;
 }
 
-
 .collision-edit-area {
   display: flex;
   align-items: center;

--- a/src/components/Cause.module.css
+++ b/src/components/Cause.module.css
@@ -1,0 +1,84 @@
+.cause {
+  display: flex;
+  position: relative;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 10px;
+  border: 1px solid #ae86ff;
+  background-color: #4c396e;
+  box-shadow: 3px 3px 2px 0px rgba(0, 0, 0, 0.4);
+}
+
+.cause-delete {
+  position: absolute;
+  top: 4px;
+  right: 2px;
+  width: 17px;
+  height: 17px;
+  cursor: pointer;
+}
+
+.cause-when {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.cause-info {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.cause-image {
+  width: 50px;
+  height: 50px;
+  margin-right: 0.5rem;
+}
+
+.cause-name {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.cause-trigger-settings {
+  display: block;
+  width: 100%;
+}
+
+.cause-trigger-settings select {
+  width: 100%;
+  cursor: pointer;
+}
+
+
+.collision-edit-area {
+  display: flex;
+  align-items: center;
+  margin-top: 0.25rem;
+}
+
+.collision-edit-buttton {
+  border: 1px solid #8447ff;
+  background-color: #4c396e;
+  border-radius: 5px;
+  cursor: pointer;
+  box-shadow: 3px 3px 2px 0px rgba(0, 0, 0, 0.4);
+  font-weight: 600;
+  margin-right: 0.5rem;
+}
+
+.collision-edit-area-token-text img {
+  width: 40px;
+  height: 40px;
+  margin-right: 0.25rem;
+}
+
+.collision-edit-area-token-text {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+}

--- a/src/components/Cause.tsx
+++ b/src/components/Cause.tsx
@@ -1,11 +1,11 @@
 import { motion } from "motion/react";
-import { updateCauseTokenData, handleRemoveCause } from "../functions";
-import { useAppStore } from "../functions/hooks";
-import { OperatorSwitch } from "./OperatorSwitch";
-import type { Cause as CauseType, CauseProps, CauseTrigger } from "../types";
-import styles from "./Cause.module.css";
-import fire from "../assets/fire.svg";
 
+import fire from "../assets/fire.svg";
+import { handleRemoveCause, updateCauseTokenData } from "../functions";
+import { useAppStore } from "../functions/hooks";
+import type { CauseProps, CauseTrigger, Cause as CauseType } from "../types";
+import styles from "./Cause.module.css";
+import { OperatorSwitch } from "./OperatorSwitch";
 
 export const Cause = ({ cause, causality, index }: CauseProps) => {
   const { updateCollisionOptionsDialog } = useAppStore();
@@ -44,27 +44,18 @@ export const Cause = ({ cause, causality, index }: CauseProps) => {
         <motion.p layout className={styles["cause-when"]}>
           When:
         </motion.p>
-        <motion.div
-          layout
-          className={styles["cause-info"]}
-        >
+        <motion.div layout className={styles["cause-info"]}>
           <motion.img
             layout
             className={styles["cause-image"]}
             src={cause?.imageUrl}
             alt={cause?.name}
           />
-          <motion.p
-            layout
-            className={styles["cause-name"]}
-          >
+          <motion.p layout className={styles["cause-name"]}>
             {cause.name}
           </motion.p>
         </motion.div>
-        <motion.div
-          layout
-          className={styles["cause-trigger-settings"]}
-        >
+        <motion.div layout className={styles["cause-trigger-settings"]}>
           <motion.select
             layout
             onChange={(event) => {
@@ -88,26 +79,18 @@ export const Cause = ({ cause, causality, index }: CauseProps) => {
             <div className={styles["collision-edit-area"]}>
               <button
                 className={styles["collision-edit-buttton"]}
-                onClick={() =>
-                  handleShowCollisionOptionsDialog(cause)
-                }
+                onClick={() => handleShowCollisionOptionsDialog(cause)}
                 title={
                   "Click here to assign a specific token to trigger the collision"
                 }
-                disabled={
-                  cause.status === "Complete" ? true : false
-                }
+                disabled={cause.status === "Complete" ? true : false}
               >
                 By...
               </button>
 
               {cause.tokenToTriggerCollision?.name &&
-                cause.tokenToTriggerCollision?.imageUrl ? (
-                <p
-                  className={
-                    styles["collision-edit-area-token-text"]
-                  }
-                >
+              cause.tokenToTriggerCollision?.imageUrl ? (
+                <p className={styles["collision-edit-area-token-text"]}>
                   <img
                     src={cause.tokenToTriggerCollision.imageUrl}
                     alt={cause.tokenToTriggerCollision.name}
@@ -125,5 +108,5 @@ export const Cause = ({ cause, causality, index }: CauseProps) => {
         </motion.div>
       </motion.div>
     </>
-  )
-}
+  );
+};

--- a/src/components/Cause.tsx
+++ b/src/components/Cause.tsx
@@ -1,0 +1,129 @@
+import { motion } from "motion/react";
+import { updateCauseTokenData, handleRemoveCause } from "../functions";
+import { useAppStore } from "../functions/hooks";
+import { OperatorSwitch } from "./OperatorSwitch";
+import type { Cause as CauseType, CauseProps, CauseTrigger } from "../types";
+import styles from "./Cause.module.css";
+import fire from "../assets/fire.svg";
+
+
+export const Cause = ({ cause, causality, index }: CauseProps) => {
+  const { updateCollisionOptionsDialog } = useAppStore();
+
+  const handleShowCollisionOptionsDialog = (cause: CauseType) => {
+    updateCollisionOptionsDialog({
+      open: true,
+      cause,
+    });
+  };
+
+  return (
+    <>
+      <motion.div
+        key={cause.causeId}
+        className={styles["cause"]}
+        initial={{ opacity: 0, y: -10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 10 }}
+        transition={{ duration: 0.25 }}
+        layout
+      >
+        {index !== 0 && (
+          <>
+            <img
+              onClick={() => {
+                handleRemoveCause(causality.id, cause.tokenId, cause.causeId);
+              }}
+              className={styles["cause-delete"]}
+              src={fire}
+              alt="Delete Cause"
+            />
+            <OperatorSwitch cause={cause} />
+          </>
+        )}
+        <motion.p layout className={styles["cause-when"]}>
+          When:
+        </motion.p>
+        <motion.div
+          layout
+          className={styles["cause-info"]}
+        >
+          <motion.img
+            layout
+            className={styles["cause-image"]}
+            src={cause?.imageUrl}
+            alt={cause?.name}
+          />
+          <motion.p
+            layout
+            className={styles["cause-name"]}
+          >
+            {cause.name}
+          </motion.p>
+        </motion.div>
+        <motion.div
+          layout
+          className={styles["cause-trigger-settings"]}
+        >
+          <motion.select
+            layout
+            onChange={(event) => {
+              return updateCauseTokenData(
+                causality.id,
+                cause.tokenId,
+                "trigger",
+                event.target.value as CauseTrigger,
+              );
+            }}
+            name="cause-triggers"
+            value={cause.trigger || ""}
+            disabled={cause?.status === "Complete" ? true : false}
+          >
+            <option value="">-- Please choose an option --</option>
+            <option value="collision">Is Collided Into</option>
+            <option value="appears">Appears</option>
+            <option value="disappears">Disappears</option>
+          </motion.select>
+          {cause.trigger === "collision" && (
+            <div className={styles["collision-edit-area"]}>
+              <button
+                className={styles["collision-edit-buttton"]}
+                onClick={() =>
+                  handleShowCollisionOptionsDialog(cause)
+                }
+                title={
+                  "Click here to assign a specific token to trigger the collision"
+                }
+                disabled={
+                  cause.status === "Complete" ? true : false
+                }
+              >
+                By...
+              </button>
+
+              {cause.tokenToTriggerCollision?.name &&
+                cause.tokenToTriggerCollision?.imageUrl ? (
+                <p
+                  className={
+                    styles["collision-edit-area-token-text"]
+                  }
+                >
+                  <img
+                    src={cause.tokenToTriggerCollision.imageUrl}
+                    alt={cause.tokenToTriggerCollision.name}
+                  />
+                  {cause.tokenToTriggerCollision.name}
+                  {cause.tokenToTriggerCollision.label
+                    ? ` / ${cause.tokenToTriggerCollision.label}`
+                    : ""}
+                </p>
+              ) : (
+                <p>...any token</p>
+              )}
+            </div>
+          )}
+        </motion.div>
+      </motion.div>
+    </>
+  )
+}

--- a/src/components/Effect.module.css
+++ b/src/components/Effect.module.css
@@ -7,14 +7,15 @@
   margin-bottom: 0.5rem;
   padding: 0.5rem;
   border-radius: 10px;
+  border: 1px solid #ae86ff;
   background-color: #4c396e;
   box-shadow: 3px 3px 2px 0px rgba(0, 0, 0, 0.4);
 }
 
 .effect-delete {
   position: absolute;
-  top: 3px;
-  right: 0px;
+  top: 4px;
+  right: 2px;
   width: 17px;
   height: 17px;
   cursor: pointer;

--- a/src/components/Effect.tsx
+++ b/src/components/Effect.tsx
@@ -30,7 +30,7 @@ export const Effect = ({
         effect,
       });
     }
-  }, [causality, activeEffectId]);
+  }, [causality, activeEffectId, effect, open, updateEffectDialog]);
 
   const handleShowEffectDialog = () => {
     updateEffectDialog({

--- a/src/components/Effect.tsx
+++ b/src/components/Effect.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import fire from "../assets/fire.svg";
 import { handleRemoveEffect, updateCauseTokenData } from "../functions";
 import { useAppStore } from "../functions/hooks";
-import type { EffectProps } from "../types";
+import type { EffectProps, CausalityStatus } from "../types";
 import styles from "./Effect.module.css";
 
 export const Effect = ({
@@ -14,8 +14,9 @@ export const Effect = ({
 }: EffectProps) => {
   const { effectDialog, updateEffectDialog } = useAppStore();
   const { activeEffectId, open } = effectDialog;
-  const cause = causality.cause;
-  const isEditAllowed = causality.cause?.status === "Complete" ? false : true;
+  const causes = causality.causes;
+  const causalityStatus: CausalityStatus = causes?.every((cause) => cause.status === "Complete") ? "Complete" : "Pending";
+  const isEditAllowed = causalityStatus === "Complete" ? false : true;
 
   useEffect(() => {
     if (activeEffectId === effect.effectId && open) {
@@ -48,13 +49,13 @@ export const Effect = ({
     >
       <img
         onClick={() => {
-          if ("isInstigator" in effect && effect.isInstigator && cause) {
+          if ("isInstigator" in effect && effect.isInstigator && causes && causes.length > 0) {
             const newInstigatorEffects = instigatorEffects.filter((ie) => {
               return ie.effectId !== effect.effectId;
             });
             updateCauseTokenData(
               causality.id,
-              cause.tokenId,
+              causes[0].tokenId,
               "instigatorEffects",
               newInstigatorEffects,
             );
@@ -64,7 +65,7 @@ export const Effect = ({
         }}
         className={styles["effect-delete"]}
         src={fire}
-        alt="Delete Causality"
+        alt="Delete Effect"
       />
 
       <div className={styles["effect-info"]}>

--- a/src/components/Effect.tsx
+++ b/src/components/Effect.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import fire from "../assets/fire.svg";
 import { handleRemoveEffect, updateCauseTokenData } from "../functions";
 import { useAppStore } from "../functions/hooks";
-import type { EffectProps, CausalityStatus } from "../types";
+import type { CausalityStatus, EffectProps } from "../types";
 import styles from "./Effect.module.css";
 
 export const Effect = ({
@@ -15,7 +15,11 @@ export const Effect = ({
   const { effectDialog, updateEffectDialog } = useAppStore();
   const { activeEffectId, open } = effectDialog;
   const causes = causality.causes;
-  const causalityStatus: CausalityStatus = causes?.every((cause) => cause.status === "Complete") ? "Complete" : "Pending";
+  const causalityStatus: CausalityStatus = causes?.every(
+    (cause) => cause.status === "Complete",
+  )
+    ? "Complete"
+    : "Pending";
   const isEditAllowed = causalityStatus === "Complete" ? false : true;
 
   useEffect(() => {
@@ -49,7 +53,12 @@ export const Effect = ({
     >
       <img
         onClick={() => {
-          if ("isInstigator" in effect && effect.isInstigator && causes && causes.length > 0) {
+          if (
+            "isInstigator" in effect &&
+            effect.isInstigator &&
+            causes &&
+            causes.length > 0
+          ) {
             const newInstigatorEffects = instigatorEffects.filter((ie) => {
               return ie.effectId !== effect.effectId;
             });

--- a/src/components/GlobalEffectDialog.tsx
+++ b/src/components/GlobalEffectDialog.tsx
@@ -36,20 +36,17 @@ export const GlobalEffectDialog = () => {
         >
           {causality && causes && causes.length === 1 ? (
             <p className={styles["dialog-pre"]}>
-              When{" "}
-              <img
-                src={causes[0]?.imageUrl}
-                alt={causes[0]?.name}
-              />
+              When <img src={causes[0]?.imageUrl} alt={causes[0]?.name} />
               <strong>{causes[0]?.name}</strong>{" "}
               {causeTriggerTextMap[causes[0]?.trigger || "default"]}
             </p>
-          ) : causes && causes.length > 1 && (
-            <p className={styles["dialog-pre"]}>
-              When all{" "}
-              <strong>Cause</strong>{" "}
-              conditions are met
-            </p>
+          ) : (
+            causes &&
+            causes.length > 1 && (
+              <p className={styles["dialog-pre"]}>
+                When all <strong>Cause</strong> conditions are met
+              </p>
+            )
           )}
 
           <Dialog.Title className={styles["dialog-title"]}>

--- a/src/components/GlobalEffectDialog.tsx
+++ b/src/components/GlobalEffectDialog.tsx
@@ -24,6 +24,8 @@ export const GlobalEffectDialog = () => {
     default: "does something...",
   };
 
+  const causes = causality?.causes;
+
   return (
     <Dialog.Root open={open}>
       <Dialog.Portal>
@@ -32,15 +34,21 @@ export const GlobalEffectDialog = () => {
           aria-describedby={undefined}
           className={styles["dialog-content"]}
         >
-          {causality && (
+          {causality && causes && causes.length === 1 ? (
             <p className={styles["dialog-pre"]}>
               When{" "}
               <img
-                src={causality.cause?.imageUrl}
-                alt={causality.cause?.name}
+                src={causes[0]?.imageUrl}
+                alt={causes[0]?.name}
               />
-              <strong>{causality.cause?.name}</strong>{" "}
-              {causeTriggerTextMap[causality.cause?.trigger || "default"]}
+              <strong>{causes[0]?.name}</strong>{" "}
+              {causeTriggerTextMap[causes[0]?.trigger || "default"]}
+            </p>
+          ) : causes && causes.length > 1 && (
+            <p className={styles["dialog-pre"]}>
+              When all{" "}
+              <strong>Cause</strong>{" "}
+              conditions are met
             </p>
           )}
 
@@ -74,7 +82,6 @@ export const GlobalEffectDialog = () => {
                   );
                 }}
                 value={effect.action || ""}
-                disabled={causality.cause?.status === "Complete" ? true : false}
               >
                 <option value="">-- Please choose an option --</option>
                 <option value="lock">Lock</option>

--- a/src/components/OperatorSwitch.module.css
+++ b/src/components/OperatorSwitch.module.css
@@ -1,0 +1,36 @@
+.OperatorSwitch {
+  margin-bottom: 0.45rem;
+}
+
+.Root {
+	all: unset;
+	width: 42px;
+	height: 18px;
+	background-color: #2b1a47;
+	border: 1px solid #8447ff;
+	border-radius: 9999px;
+	position: relative;
+
+}
+
+.Thumb {
+	display: block;
+	width: 14px;
+	height: 14px;
+	background-color: #ae86ff;
+	border-radius: 9999px;
+  box-shadow: 3px 3px 2px 0px rgba(0, 0, 0, 0.4);
+	transition: transform 100ms;
+	transform: translateX(2px);
+	will-change: transform;
+	&[data-state="checked"] {
+		transform: translateX(26px);
+	}
+}
+
+.Label {
+	font-size: 12px;
+  font-weight: 600;
+  text-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.4);
+	user-select: none;
+}

--- a/src/components/OperatorSwitch.module.css
+++ b/src/components/OperatorSwitch.module.css
@@ -3,34 +3,33 @@
 }
 
 .Root {
-	all: unset;
-	width: 42px;
-	height: 18px;
-	background-color: #2b1a47;
-	border: 1px solid #8447ff;
-	border-radius: 9999px;
-	position: relative;
-
+  all: unset;
+  width: 42px;
+  height: 18px;
+  background-color: #2b1a47;
+  border: 1px solid #8447ff;
+  border-radius: 9999px;
+  position: relative;
 }
 
 .Thumb {
-	display: block;
-	width: 14px;
-	height: 14px;
-	background-color: #ae86ff;
-	border-radius: 9999px;
+  display: block;
+  width: 14px;
+  height: 14px;
+  background-color: #ae86ff;
+  border-radius: 9999px;
   box-shadow: 3px 3px 2px 0px rgba(0, 0, 0, 0.4);
-	transition: transform 100ms;
-	transform: translateX(2px);
-	will-change: transform;
-	&[data-state="checked"] {
-		transform: translateX(26px);
-	}
+  transition: transform 100ms;
+  transform: translateX(2px);
+  will-change: transform;
+  &[data-state="checked"] {
+    transform: translateX(26px);
+  }
 }
 
 .Label {
-	font-size: 12px;
+  font-size: 12px;
   font-weight: 600;
   text-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.4);
-	user-select: none;
+  user-select: none;
 }

--- a/src/components/OperatorSwitch.tsx
+++ b/src/components/OperatorSwitch.tsx
@@ -1,0 +1,52 @@
+import { Switch } from "radix-ui";
+import styles from "./OperatorSwitch.module.css";
+import { updateCauseTokenData } from "../functions";
+import type { CauseOperator, OperatorSwitchProps } from "../types";
+
+export const OperatorSwitch = ({ cause }: OperatorSwitchProps) => {
+  const { operator } = cause;
+
+  const handleOnSwitchChange = (checked: boolean) => {
+    const newOperator: CauseOperator = checked ? "OR" : "AND"
+    updateCauseTokenData(
+      cause.causalityId,
+      cause.tokenId,
+      "operator",
+      newOperator,
+    );
+  }
+
+  return (
+    <form>
+      <div className={styles.OperatorSwitch} style={{ display: "flex", alignItems: "center" }}>
+        <label
+          className={styles.Label}
+          htmlFor="and-operator"
+          style={{ 
+            paddingRight: 5,
+            color: operator === "AND" ? "#3bf05c" : "white"
+          }}
+        >
+          AND
+        </label>
+        <Switch.Root
+          onCheckedChange={handleOnSwitchChange}
+          checked={operator === "AND" ? false : true}
+          className={styles.Root}
+        >
+          <Switch.Thumb className={styles.Thumb} />
+        </Switch.Root>
+        <label
+          className={styles.Label}
+          htmlFor="or-operator"
+          style={{
+            paddingLeft: 5,
+            color: operator === "OR" ? "#3bf05c" : "white"
+          }}
+        >
+          OR
+        </label>
+      </div>
+    </form>
+  )
+};

--- a/src/components/OperatorSwitch.tsx
+++ b/src/components/OperatorSwitch.tsx
@@ -1,30 +1,34 @@
 import { Switch } from "radix-ui";
-import styles from "./OperatorSwitch.module.css";
+
 import { updateCauseTokenData } from "../functions";
 import type { CauseOperator, OperatorSwitchProps } from "../types";
+import styles from "./OperatorSwitch.module.css";
 
 export const OperatorSwitch = ({ cause }: OperatorSwitchProps) => {
   const { operator } = cause;
 
   const handleOnSwitchChange = (checked: boolean) => {
-    const newOperator: CauseOperator = checked ? "OR" : "AND"
+    const newOperator: CauseOperator = checked ? "OR" : "AND";
     updateCauseTokenData(
       cause.causalityId,
       cause.tokenId,
       "operator",
       newOperator,
     );
-  }
+  };
 
   return (
     <form>
-      <div className={styles.OperatorSwitch} style={{ display: "flex", alignItems: "center" }}>
+      <div
+        className={styles.OperatorSwitch}
+        style={{ display: "flex", alignItems: "center" }}
+      >
         <label
           className={styles.Label}
           htmlFor="and-operator"
-          style={{ 
+          style={{
             paddingRight: 5,
-            color: operator === "AND" ? "#3bf05c" : "white"
+            color: operator === "AND" ? "#3bf05c" : "white",
           }}
         >
           AND
@@ -41,12 +45,12 @@ export const OperatorSwitch = ({ cause }: OperatorSwitchProps) => {
           htmlFor="or-operator"
           style={{
             paddingLeft: 5,
-            color: operator === "OR" ? "#3bf05c" : "white"
+            color: operator === "OR" ? "#3bf05c" : "white",
           }}
         >
           OR
         </label>
       </div>
     </form>
-  )
+  );
 };

--- a/src/components/TokenPool.tsx
+++ b/src/components/TokenPool.tsx
@@ -2,8 +2,9 @@ import { useAppStore } from "../functions/hooks";
 import { Token } from "./Token";
 import styles from "./TokenPool.module.css";
 import { Draggable } from "./dnd/Draggable";
+import type { TokenPoolProps } from "../types";
 
-export const TokenPool = () => {
+export const TokenPool = ({ height }: TokenPoolProps) => {
   const { tokens } = useAppStore();
 
   const populateTokenPool = () => {
@@ -27,7 +28,7 @@ export const TokenPool = () => {
 
   return (
     <section className={styles["tokenpool-section"]}>
-      <div className={styles["tokenpool-scroll-area"]}>
+      <div style={{ height: height }} className={styles["tokenpool-scroll-area"]}>
         <h2 className={styles["tokenpool-title"]}>Token Pool</h2>
         <div className={styles["tokenpool-token-area"]}>
           {populateTokenPool()}

--- a/src/components/TokenPool.tsx
+++ b/src/components/TokenPool.tsx
@@ -1,8 +1,8 @@
 import { useAppStore } from "../functions/hooks";
+import type { TokenPoolProps } from "../types";
 import { Token } from "./Token";
 import styles from "./TokenPool.module.css";
 import { Draggable } from "./dnd/Draggable";
-import type { TokenPoolProps } from "../types";
 
 export const TokenPool = ({ height }: TokenPoolProps) => {
   const { tokens } = useAppStore();
@@ -28,7 +28,10 @@ export const TokenPool = ({ height }: TokenPoolProps) => {
 
   return (
     <section className={styles["tokenpool-section"]}>
-      <div style={{ height: height }} className={styles["tokenpool-scroll-area"]}>
+      <div
+        style={{ height: height }}
+        className={styles["tokenpool-scroll-area"]}
+      >
         <h2 className={styles["tokenpool-title"]}>Token Pool</h2>
         <div className={styles["tokenpool-token-area"]}>
           {populateTokenPool()}

--- a/src/components/dnd/Droppable.tsx
+++ b/src/components/dnd/Droppable.tsx
@@ -37,7 +37,8 @@ export const Droppable = ({ children, id }: DroppableProps) => {
     transition: "box-shadow 0.25s ease",
   };
 
-  const style = id === DROP_ZONE_ID ? causalityZoneStyles : causeAndEffectZoneStyles;
+  const style =
+    id === DROP_ZONE_ID ? causalityZoneStyles : causeAndEffectZoneStyles;
 
   return (
     <motion.div

--- a/src/components/dnd/Droppable.tsx
+++ b/src/components/dnd/Droppable.tsx
@@ -14,24 +14,30 @@ export const Droppable = ({ children, id }: DroppableProps) => {
     border: isOver ? "1px solid white" : "1px solid #8447ff",
     borderRadius: "10px",
     transition: "border-color 0.5s ease",
+    width: "100%",
+    boxShadow: isOver
+      ? "0px 0px 5px 0px rgb(255, 255, 255)"
+      : "0px 0px 5px 0px rgba(0, 0, 0, 0.2)",
   };
 
-  const effectsZoneStyles: CSSProperties = {
+  const causeAndEffectZoneStyles: CSSProperties = {
     display: "flex",
     flexDirection: "column",
-    justifyContent: "space-between",
-    backgroundColor: "#696969",
+    justifyContent: "flex-start",
+    backgroundColor: "#7a7a7a",
     flex: 1,
     padding: "0.5rem",
     marginLeft: "0.5rem",
     borderRadius: "10px",
     boxShadow: isOver
-      ? "3px 3px 2px 0px rgb(255, 255, 255)"
+      ? "0px 0px 5px 0px rgb(255, 255, 255)"
       : "3px 3px 2px 0px rgba(0, 0, 0, 0.2)",
-    transition: "box-shadow 0.5s ease",
+    border: isOver ? "1px solid white" : "1px solid transparent",
+
+    transition: "box-shadow 0.25s ease",
   };
 
-  const style = id === DROP_ZONE_ID ? causalityZoneStyles : effectsZoneStyles;
+  const style = id === DROP_ZONE_ID ? causalityZoneStyles : causeAndEffectZoneStyles;
 
   return (
     <motion.div
@@ -40,8 +46,8 @@ export const Droppable = ({ children, id }: DroppableProps) => {
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: 10 }}
-      transition={{ duration: 0.25 }}
-      layout
+      transition={{ duration: 0 }}
+      layout="position"
     >
       {children}
     </motion.div>

--- a/src/functions/boundingBox.ts
+++ b/src/functions/boundingBox.ts
@@ -1,10 +1,10 @@
 import {
   BoundingBox,
-  Image,
   Math2,
   Shape,
   buildShape,
 } from "@owlbear-rodeo/sdk";
+import { BoundingBoxObject } from "../types";
 
 interface Rectangle extends Shape {
   shapeType: "RECTANGLE";
@@ -53,7 +53,7 @@ function getRectangleBoundingBox(rectangle: Rectangle) {
   return Math2.boundingBox(corners);
 }
 
-export function getImageBoundingBox(image: Image) {
+export function getImageBoundingBox(image: BoundingBoxObject) {
   if (!image.grid) return;
 
   const scaleDpi = 150 / image.grid.dpi;

--- a/src/functions/boundingBox.ts
+++ b/src/functions/boundingBox.ts
@@ -1,9 +1,5 @@
-import {
-  BoundingBox,
-  Math2,
-  Shape,
-  buildShape,
-} from "@owlbear-rodeo/sdk";
+import { BoundingBox, Math2, Shape, buildShape } from "@owlbear-rodeo/sdk";
+
 import { BoundingBoxObject } from "../types";
 
 interface Rectangle extends Shape {

--- a/src/functions/checkForCollisions.ts
+++ b/src/functions/checkForCollisions.ts
@@ -68,7 +68,7 @@ export const checkForCollisions = async (
                 const itemMetaData = itemToUpdate.metadata[ID];
                 const causalities = itemMetaData.causalities;
                 if (causalities && causalities.length > 0) {
-                  for (let causality of causalities) {
+                  for (const causality of causalities) {
                     const causes = (causality.causes || []).sort((a, b) =>
                       new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1,
                     );

--- a/src/functions/checkForCollisions.ts
+++ b/src/functions/checkForCollisions.ts
@@ -1,7 +1,7 @@
 import OBR, { type Image } from "@owlbear-rodeo/sdk";
 
 import { ID, underway } from "../constants";
-import { CausalityToken, BoundingBoxObject } from "../types";
+import { BoundingBoxObject, CausalityToken } from "../types";
 import { getImageBoundingBox, intersect } from "./boundingBox";
 
 export const hasCollisionOccured = (a: CausalityToken, b: CausalityToken) => {
@@ -26,7 +26,7 @@ export const checkForCollisions = async (
       offset: {
         x: currentTarget.grid.offset.x,
         y: currentTarget.grid.offset.y,
-      }
+      },
     },
     scale: {
       x: currentTarget.scale.x,
@@ -41,12 +41,14 @@ export const checkForCollisions = async (
       x: currentTarget.position.x,
       y: currentTarget.position.y,
     },
-  }
+  };
 
   if (currentTarget) {
     for (const cToken of tokensToCheck) {
       if (currentTargetID !== cToken.id) {
-        const tokenBeingDraggedBB = getImageBoundingBox(boundingBoxCurrentTargetObject);
+        const tokenBeingDraggedBB = getImageBoundingBox(
+          boundingBoxCurrentTargetObject,
+        );
         const tokenWithCollisionDetection = getImageBoundingBox(cToken);
         if (tokenBeingDraggedBB && tokenWithCollisionDetection) {
           const collisionHasOccured = intersect(
@@ -67,7 +69,9 @@ export const checkForCollisions = async (
                 const causalities = itemMetaData.causalities;
                 if (causalities && causalities.length > 0) {
                   for (let causality of causalities) {
-                    const causes = (causality.causes || []).sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1);
+                    const causes = (causality.causes || []).sort((a, b) =>
+                      new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1,
+                    );
                     for (const cause of causes) {
                       if (cause) {
                         if (cause.isCollided === false) {
@@ -81,7 +85,10 @@ export const checkForCollisions = async (
                           // Successful Collision!
                           cause.isCollided = true;
                           const instigatorEffects = causes[0].instigatorEffects;
-                          if (instigatorEffects && instigatorEffects.length > 0) {
+                          if (
+                            instigatorEffects &&
+                            instigatorEffects.length > 0
+                          ) {
                             for (const ie of instigatorEffects) {
                               const oldTokenID = ie.tokenId;
                               ie.originalCauseTokenId = oldTokenID;

--- a/src/functions/checkForCollisions.ts
+++ b/src/functions/checkForCollisions.ts
@@ -1,7 +1,7 @@
 import OBR, { type Image } from "@owlbear-rodeo/sdk";
 
 import { ID, underway } from "../constants";
-import { CausalityToken } from "../types";
+import { CausalityToken, BoundingBoxObject } from "../types";
 import { getImageBoundingBox, intersect } from "./boundingBox";
 
 export const hasCollisionOccured = (a: CausalityToken, b: CausalityToken) => {
@@ -20,10 +20,33 @@ export const checkForCollisions = async (
   const currentTarget = item as CausalityToken;
   const currentTargetID = item.id;
   const tokensToCheck = collisionTokensRef.current;
+  const boundingBoxCurrentTargetObject: BoundingBoxObject = {
+    grid: {
+      dpi: currentTarget.grid.dpi,
+      offset: {
+        x: currentTarget.grid.offset.x,
+        y: currentTarget.grid.offset.y,
+      }
+    },
+    scale: {
+      x: currentTarget.scale.x,
+      y: currentTarget.scale.y,
+    },
+    rotation: currentTarget.rotation,
+    image: {
+      width: currentTarget.image.width,
+      height: currentTarget.image.height,
+    },
+    position: {
+      x: currentTarget.position.x,
+      y: currentTarget.position.y,
+    },
+  }
+
   if (currentTarget) {
     for (const cToken of tokensToCheck) {
-      if (currentTarget.id !== cToken.id) {
-        const tokenBeingDraggedBB = getImageBoundingBox(currentTarget);
+      if (currentTargetID !== cToken.id) {
+        const tokenBeingDraggedBB = getImageBoundingBox(boundingBoxCurrentTargetObject);
         const tokenWithCollisionDetection = getImageBoundingBox(cToken);
         if (tokenBeingDraggedBB && tokenWithCollisionDetection) {
           const collisionHasOccured = intersect(
@@ -44,24 +67,26 @@ export const checkForCollisions = async (
                 const causalities = itemMetaData.causalities;
                 if (causalities && causalities.length > 0) {
                   for (let causality of causalities) {
-                    const cause = causality.cause;
-                    if (cause) {
-                      if (cause.isCollided === false) {
-                        // Check if there's a scope of only 1 specific token that should be triggering the collision.
-                        if (
-                          cause.tokenToTriggerCollision?.id &&
-                          cause.tokenToTriggerCollision.id !== currentTargetID
-                        ) {
-                          return;
-                        }
-                        // Successful Collision!
-                        cause.isCollided = true;
-                        const instigatorEffects = cause.instigatorEffects;
-                        if (instigatorEffects && instigatorEffects.length > 0) {
-                          for (const ie of instigatorEffects) {
-                            const oldTokenID = ie.tokenId;
-                            ie.originalCauseTokenId = oldTokenID;
-                            ie.tokenId = currentTargetID;
+                    const causes = (causality.causes || []).sort((a, b) => new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1);
+                    for (const cause of causes) {
+                      if (cause) {
+                        if (cause.isCollided === false) {
+                          // Check if there's a scope of only 1 specific token that should be triggering the collision.
+                          if (
+                            cause.tokenToTriggerCollision?.id &&
+                            cause.tokenToTriggerCollision.id !== currentTargetID
+                          ) {
+                            return;
+                          }
+                          // Successful Collision!
+                          cause.isCollided = true;
+                          const instigatorEffects = causes[0].instigatorEffects;
+                          if (instigatorEffects && instigatorEffects.length > 0) {
+                            for (const ie of instigatorEffects) {
+                              const oldTokenID = ie.tokenId;
+                              ie.originalCauseTokenId = oldTokenID;
+                              ie.tokenId = currentTargetID;
+                            }
                           }
                         }
                       }

--- a/src/functions/handleRemoveCausality.ts
+++ b/src/functions/handleRemoveCausality.ts
@@ -10,8 +10,14 @@ export const handleRemoveCausality = (c: Causality) => {
       tokensToRemoveCausalityFrom.push(effect.tokenId);
     });
   }
-  if (c.cause) {
-    tokensToRemoveCausalityFrom.push(c.cause.tokenId);
+  if (c.causes && c.causes.length > 0) {
+    c.causes.forEach((cause) => {
+      tokensToRemoveCausalityFrom.push(cause.tokenId);
+    });
+  }
+
+  if (c.tokenId) {
+    tokensToRemoveCausalityFrom.push(c.tokenId);
   }
 
   OBR.scene.items.updateItems(

--- a/src/functions/handleRemoveCausality.ts
+++ b/src/functions/handleRemoveCausality.ts
@@ -25,7 +25,7 @@ export const handleRemoveCausality = (c: Causality) => {
       return tokensToRemoveCausalityFrom.includes(item.id);
     },
     (items) => {
-      for (let item of items) {
+      for (const item of items) {
         const itemToUpdate = item as CausalityToken;
         itemToUpdate.metadata[ID].causalities = itemToUpdate.metadata[
           ID

--- a/src/functions/handleRemoveCause.ts
+++ b/src/functions/handleRemoveCause.ts
@@ -1,12 +1,11 @@
 import OBR from "@owlbear-rodeo/sdk";
-
 import { ID } from "../constants";
 import type { CausalityToken } from "../types";
 
-export const handleRemoveEffect = (
+export const handleRemoveCause = (
   causalityID: string,
   tokenID: string,
-  effectID: string,
+  causeID: string,
 ) => {
   OBR.scene.items.updateItems(
     (item) => {
@@ -21,13 +20,13 @@ export const handleRemoveEffect = (
         });
         if (matchingCausalityIdx !== -1) {
           const matchingCausality = causalities[matchingCausalityIdx];
-          const effects = matchingCausality.effects;
-          if (effects && effects.length > 0) {
-            const matchingEffectIndex = effects?.findIndex((effect) => {
-              return effect.effectId === effectID;
+          const causes = matchingCausality.causes;
+          if (causes && causes.length > 0) {
+            const matchingCauseIndex = causes?.findIndex((cause) => {
+              return cause.causeId === causeID;
             });
-            if (matchingEffectIndex !== -1) {
-              effects.splice(matchingEffectIndex, 1);
+            if (matchingCauseIndex !== -1) {
+              causes.splice(matchingCauseIndex, 1);
             }
 
             // Cleanup to remove the causality on that token if it's empty.

--- a/src/functions/handleRemoveCause.ts
+++ b/src/functions/handleRemoveCause.ts
@@ -1,4 +1,5 @@
 import OBR from "@owlbear-rodeo/sdk";
+
 import { ID } from "../constants";
 import type { CausalityToken } from "../types";
 
@@ -32,7 +33,9 @@ export const handleRemoveCause = (
             // Cleanup to remove the causality on that token if it's empty.
             if (
               matchingCausality.effects?.length === 0 &&
-              (!matchingCausality.causes || (matchingCausality.causes && matchingCausality.causes.length === 0))
+              (!matchingCausality.causes ||
+                (matchingCausality.causes &&
+                  matchingCausality.causes.length === 0))
             ) {
               causalities.splice(matchingCausalityIdx, 1);
             }

--- a/src/functions/handleRemoveEffect.ts
+++ b/src/functions/handleRemoveEffect.ts
@@ -33,7 +33,9 @@ export const handleRemoveEffect = (
             // Cleanup to remove the causality on that token if it's empty.
             if (
               matchingCausality.effects?.length === 0 &&
-              (!matchingCausality.causes || (matchingCausality.causes && matchingCausality.causes.length === 0))
+              (!matchingCausality.causes ||
+                (matchingCausality.causes &&
+                  matchingCausality.causes.length === 0))
             ) {
               causalities.splice(matchingCausalityIdx, 1);
             }

--- a/src/functions/handleResetCausality.ts
+++ b/src/functions/handleResetCausality.ts
@@ -21,7 +21,7 @@ export const handleResetCausality = (c: Causality) => {
       return tokensToResetCausalityOn.includes(item.id);
     },
     (items) => {
-      for (let item of items) {
+      for (const item of items) {
         const itemToUpdate = item as CausalityToken;
         const causalityMetaData = itemToUpdate.metadata[ID];
         const causalities = causalityMetaData.causalities;

--- a/src/functions/handleResetCausality.ts
+++ b/src/functions/handleResetCausality.ts
@@ -10,8 +10,10 @@ export const handleResetCausality = (c: Causality) => {
       tokensToResetCausalityOn.push(effect.tokenId);
     });
   }
-  if (c.cause) {
-    tokensToResetCausalityOn.push(c.cause.tokenId);
+  if (c.causes && c.causes.length > 0) {
+    c.causes.forEach((cause) => {
+      tokensToResetCausalityOn.push(cause.tokenId);
+    });
   }
 
   OBR.scene.items.updateItems(
@@ -26,11 +28,13 @@ export const handleResetCausality = (c: Causality) => {
         if (causalities && causalities.length > 0) {
           causalities.forEach((causality) => {
             if (causality.id === c.id) {
-              const cause = causality.cause;
-              if (cause) {
-                cause.status = "Pending";
-                if (cause.isCollided) {
-                  cause.isCollided = false;
+              const causes = causality.causes;
+              if (causes && causes.length > 0) {
+                for (const cause of causes) {
+                  cause.status = "Pending";
+                  if (cause.isCollided) {
+                    cause.isCollided = false;
+                  }
                 }
               }
             }

--- a/src/functions/hooks/useCausalityPointer.ts
+++ b/src/functions/hooks/useCausalityPointer.ts
@@ -80,7 +80,7 @@ export const useCausalityPointer = () => {
                       return item.id === itemToUpdate.id;
                     },
                     (items) => {
-                      for (let item of items) {
+                      for (const item of items) {
                         if (item.id === itemToUpdate.id) {
                           item.position = itemToUpdate.position;
                         }
@@ -110,7 +110,7 @@ export const useCausalityPointer = () => {
                     return item.id === itemToUpdate.id;
                   },
                   (items) => {
-                    for (let item of items) {
+                    for (const item of items) {
                       if (item.id === itemToUpdate.id) {
                         item.position = itemToUpdate.position;
                       }
@@ -121,6 +121,7 @@ export const useCausalityPointer = () => {
                 interaction = "";
                 underway.collisions = {};
               } catch (e) {
+                console.log(e);
                 stop();
                 interaction = "";
                 underway.collisions = {};
@@ -130,5 +131,5 @@ export const useCausalityPointer = () => {
         },
       });
     });
-  }, []);
+  }, [collisionTokensRef]);
 };

--- a/src/functions/hooks/useCausalityTokenSetterMenuContext.ts
+++ b/src/functions/hooks/useCausalityTokenSetterMenuContext.ts
@@ -112,7 +112,7 @@ export const useCausalityTokenSetterMenuContext = () => {
                           trigger: "collision",
                           causeId: randomUUID(),
                           timestamp,
-                        }
+                        },
                       ],
                       effects: [
                         {
@@ -142,7 +142,7 @@ export const useCausalityTokenSetterMenuContext = () => {
         if (role === "GM") {
           setupContextMenu();
         }
-      })
+      });
     });
   }, []);
 };

--- a/src/functions/hooks/useCausalityTokenSetterMenuContext.ts
+++ b/src/functions/hooks/useCausalityTokenSetterMenuContext.ts
@@ -41,7 +41,7 @@ export const useCausalityTokenSetterMenuContext = () => {
         onClick: async (context) => {
           if (isImage(context?.items?.[0])) {
             await OBR.scene.items.updateItems(context?.items, (images) => {
-              for (let image of images) {
+              for (const image of images) {
                 const selectedItem = image as CausalityToken;
                 if (
                   selectedItem?.metadata?.[ID]?.["isCausalityToken"] === true
@@ -86,7 +86,7 @@ export const useCausalityTokenSetterMenuContext = () => {
         onClick: async (context) => {
           if (isImage(context?.items?.[0])) {
             await OBR.scene.items.updateItems(context?.items, (images) => {
-              for (let image of images) {
+              for (const image of images) {
                 const selectedItem = image as CausalityToken;
                 if (selectedItem.visible === true) {
                   selectedItem.visible = false;

--- a/src/functions/hooks/useCausalityTokenSetterMenuContext.ts
+++ b/src/functions/hooks/useCausalityTokenSetterMenuContext.ts
@@ -91,28 +91,33 @@ export const useCausalityTokenSetterMenuContext = () => {
                 if (selectedItem.visible === true) {
                   selectedItem.visible = false;
                 }
-                const uniqueKey = randomUUID();
+                const uniqueCausalityId = randomUUID();
+                const timestamp = new Date().toISOString();
                 selectedItem.metadata[ID] = {
                   isCausalityToken: true,
                   causalities: [
                     {
-                      id: uniqueKey,
-                      timestamp: new Date().toISOString(),
-                      cause: {
-                        status: "Pending",
-                        delay: "0",
-                        isCollided: false,
-                        tokenId: selectedItem.id,
-                        causalityId: uniqueKey,
-                        name: selectedItem.name,
-                        label: selectedItem.text?.plainText,
-                        imageUrl: selectedItem.image.url,
-                        trigger: "collision",
-                      },
+                      id: uniqueCausalityId,
+                      timestamp,
+                      causes: [
+                        {
+                          status: "Pending",
+                          delay: "0",
+                          isCollided: false,
+                          tokenId: selectedItem.id,
+                          causalityId: uniqueCausalityId,
+                          name: selectedItem.name,
+                          label: selectedItem.text?.plainText,
+                          imageUrl: selectedItem.image.url,
+                          trigger: "collision",
+                          causeId: randomUUID(),
+                          timestamp,
+                        }
+                      ],
                       effects: [
                         {
                           tokenId: selectedItem.id,
-                          causalityId: uniqueKey,
+                          causalityId: uniqueCausalityId,
                           name: selectedItem.name,
                           label: selectedItem.text?.plainText,
                           imageUrl: selectedItem.image.url,
@@ -133,7 +138,11 @@ export const useCausalityTokenSetterMenuContext = () => {
     };
 
     OBR.onReady(() => {
-      setupContextMenu();
+      OBR.player.getRole().then((role) => {
+        if (role === "GM") {
+          setupContextMenu();
+        }
+      })
     });
   }, []);
 };

--- a/src/functions/hooks/useCausalityTokenSetterMenuContext.ts
+++ b/src/functions/hooks/useCausalityTokenSetterMenuContext.ts
@@ -98,6 +98,7 @@ export const useCausalityTokenSetterMenuContext = () => {
                   causalities: [
                     {
                       id: uniqueCausalityId,
+                      tokenId: selectedItem.id,
                       timestamp,
                       causes: [
                         {

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -1,6 +1,7 @@
 export { handleRemoveCausality } from "./handleRemoveCausality";
 export { updateCauseTokenData, updateEffectTokenData } from "./updateTokenData";
 export { handleRemoveEffect } from "./handleRemoveEffect";
+export { handleRemoveCause } from "./handleRemoveCause";
 export { handleResetCausality } from "./handleResetCausality";
 export { triggerEffectTokens } from "./triggerEffectTokens";
 export { getImageBoundingBox } from "./boundingBox";

--- a/src/functions/triggerEffectTokens.ts
+++ b/src/functions/triggerEffectTokens.ts
@@ -100,28 +100,30 @@ export const triggerEffectTokens = async (
             if (causality.id === causalityID) {
               if (!logs[causality.id]) {
                 logs[causality.id] = {
-                  cause: {},
+                  causes: [],
                   effects: [],
                   logID: "",
                 };
               }
 
-              const cause = causality.cause;
-              if (cause) {
-                cause.status = "Complete";
-                if (
-                  cause.instigatorEffects &&
-                  cause.instigatorEffects.length > 0
-                ) {
-                  for (const ie of cause.instigatorEffects) {
-                    instigatorArray.push([cause, ie]);
+              const causes = causality.causes;
+              if (causes && causes.length > 0) {
+                for (const cause of causes) {
+                  cause.status = "Complete";
+                  if (
+                    cause.instigatorEffects &&
+                    cause.instigatorEffects.length > 0
+                  ) {
+                    for (const ie of cause.instigatorEffects) {
+                      instigatorArray.push([cause, ie]);
+                    }
                   }
+                  logs[causality.id].causes.push({
+                    name: cause?.name,
+                    imageUrl: cause?.imageUrl,
+                    trigger: cause?.trigger,
+                  });
                 }
-                logs[causality.id].cause = {
-                  name: cause?.name,
-                  imageUrl: cause?.imageUrl,
-                  trigger: cause?.trigger,
-                };
               }
               const effects = causality.effects;
               if (effects && effects.length > 0) {
@@ -150,16 +152,16 @@ export const triggerEffectTokens = async (
             updateItemByEffect(ie, triggeringItem);
             if (!logs[triggeringItem.id]) {
               logs[triggeringItem.id] = {
-                cause: {},
+                causes: [],
                 effects: [],
                 logID: "",
               };
             }
-            logs[triggeringItem.id].cause = {
+            logs[triggeringItem.id].causes.push({
               name: cause?.name,
               imageUrl: cause?.imageUrl,
               trigger: cause?.trigger,
-            };
+            });
             logs[triggeringItem.id].effects.push({
               name: ie?.name,
               imageUrl: ie?.imageUrl,

--- a/src/functions/triggerEffectTokens.ts
+++ b/src/functions/triggerEffectTokens.ts
@@ -90,9 +90,9 @@ export const triggerEffectTokens = async (
       return false;
     },
     (items) => {
-      let instigatorArray: [Cause, InstigatorEffect][] = [];
+      const instigatorArray: [Cause, InstigatorEffect][] = [];
       for (const item of items) {
-        let itemToUpdate = item as CausalityToken;
+        const itemToUpdate = item as CausalityToken;
         const causalityMetadata = itemToUpdate.metadata[ID];
         const causalities = causalityMetadata.causalities;
         if (causalities && causalities.length > 0) {

--- a/src/functions/updateTokenData.ts
+++ b/src/functions/updateTokenData.ts
@@ -53,7 +53,9 @@ export const updateEffectTokenData = <K extends keyof Effect>(
         });
         if (matchingCausality) {
           const effects = matchingCausality.effects;
-          const instigatorEffects = (matchingCausality.causes || []).flatMap((cause) => cause.instigatorEffects || []);
+          const instigatorEffects = (matchingCausality.causes || []).flatMap(
+            (cause) => cause.instigatorEffects || [],
+          );
           const allEffects = instigatorEffects
             ? [...(effects || []), ...(instigatorEffects || [])]
             : effects;

--- a/src/functions/updateTokenData.ts
+++ b/src/functions/updateTokenData.ts
@@ -21,9 +21,11 @@ export const updateCauseTokenData = <K extends keyof Cause>(
           return causality.id === causalityID;
         });
         if (matchingCausality) {
-          const causeToken = matchingCausality.cause;
-          if (causeToken && causeToken.tokenId === tokenID) {
-            causeToken[propName] = propValue;
+          const causes = matchingCausality.causes || [];
+          for (const cause of causes) {
+            if (cause && cause.tokenId === tokenID) {
+              cause[propName] = propValue;
+            }
           }
         }
       }
@@ -51,8 +53,7 @@ export const updateEffectTokenData = <K extends keyof Effect>(
         });
         if (matchingCausality) {
           const effects = matchingCausality.effects;
-          const instigatorEffects = matchingCausality?.cause?.instigatorEffects;
-
+          const instigatorEffects = (matchingCausality.causes || []).flatMap((cause) => cause.instigatorEffects || []);
           const allEffects = instigatorEffects
             ? [...(effects || []), ...(instigatorEffects || [])]
             : effects;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Image, ImageGrid, ImageContent, Vector2 } from "@owlbear-rodeo/sdk";
+import { Image } from "@owlbear-rodeo/sdk";
 import type { ReactElement } from "react";
 import React from "react";
 
@@ -116,7 +116,7 @@ export type CausalityManagerProps = {
 
 export type CausalitiesProps = {
   height: number;
-}
+};
 
 export type TokenPoolProps = {
   height: number;
@@ -147,7 +147,7 @@ export type CauseProps = {
   index: number;
   causality: Causality;
   cause: Cause;
-}
+};
 
 export type EffectProps = {
   causality: Causality;
@@ -172,23 +172,23 @@ export type OperatorSwitchProps = {
 
 export type BoundingBoxObject = {
   grid: {
-    dpi: number
+    dpi: number;
     offset: {
-      x: number,
-      y: number,
-    }
-  }
+      x: number;
+      y: number;
+    };
+  };
   scale: {
-    x: number,
-    y: number,
-  },
-  rotation: number,
+    x: number;
+    y: number;
+  };
+  rotation: number;
   image: {
-    width: number,
-    height: number,
-  },
+    width: number;
+    height: number;
+  };
   position: {
-    x: number,
-    y: number,
-  },
-}
+    x: number;
+    y: number;
+  };
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { Image } from "@owlbear-rodeo/sdk";
+import { Image, ImageGrid, ImageContent, Vector2 } from "@owlbear-rodeo/sdk";
 import type { ReactElement } from "react";
 import React from "react";
 
@@ -17,6 +17,7 @@ export type EffectAction =
 export type CausalityStatus = "Pending" | "Complete";
 
 export type Destination = "REMOTE" | "LOCAL" | "ALL";
+export type CauseOperator = "AND" | "OR";
 
 export type Broadcast = {
   channel: string;
@@ -53,16 +54,20 @@ export type TokenToTriggerCollision = {
 export type Cause = TokenData & {
   trigger: CauseTrigger;
   status: CausalityStatus;
-  delay: string;
+  delay?: string;
+  timestamp: string;
+  causeId: string;
   isCollided: boolean;
   tokenToTriggerCollision?: TokenToTriggerCollision;
   instigatorEffects?: InstigatorEffect[];
+  operator?: CauseOperator;
 };
 
 export type Causality = {
   id: string;
+  tokenId: string;
   timestamp: string;
-  cause?: Cause;
+  causes?: Cause[];
   effects?: Effect[];
 };
 
@@ -91,6 +96,7 @@ export type CollisionOptionsDialogConfig = {
 
 export type AppContextProps = {
   tokens: CausalityToken[];
+  causalities: Causality[];
   collisionTokensRef: React.RefObject<CausalityToken[]>;
   effectDialog: EffectDialogConfig;
   updateEffectDialog: (effectDialog: EffectDialogConfig) => void;
@@ -108,8 +114,12 @@ export type CausalityManagerProps = {
   tokens: CausalityToken[];
 };
 
+export type CausalitiesProps = {
+  height: number;
+}
+
 export type TokenPoolProps = {
-  tokens: CausalityToken[];
+  height: number;
 };
 
 export type TokenProps = {
@@ -133,6 +143,12 @@ export type SortableProps = {
   id: string;
 };
 
+export type CauseProps = {
+  index: number;
+  causality: Causality;
+  cause: Cause;
+}
+
 export type EffectProps = {
   causality: Causality;
   effect: Effect | InstigatorEffect;
@@ -145,7 +161,34 @@ export type BroadcastInputProps = {
 };
 
 export type CausalityLog = {
-  cause: Partial<Cause>;
+  causes: Partial<Cause>[];
   effects: Partial<Effect>[];
   logID: string;
 };
+
+export type OperatorSwitchProps = {
+  cause: Cause;
+};
+
+export type BoundingBoxObject = {
+  grid: {
+    dpi: number
+    offset: {
+      x: number,
+      y: number,
+    }
+  }
+  scale: {
+    x: number,
+    y: number,
+  },
+  rotation: number,
+  image: {
+    width: number,
+    height: number,
+  },
+  position: {
+    x: number,
+    y: number,
+  },
+}


### PR DESCRIPTION
This PR:

- Refactors the extension logic to be able to handle both multiple **causes** and **effects** within a **causality**. Setting up the causes requires you set an "AND" or "OR" operator between each one.
- Adds a handlebar to resize the height of either the token pool or the causality zone - so that you can give yourself more real estate if you're working with just the causality zone.