### PR TITLE
add cover vs collision feature

### DIFF
--- a/src/AppProvider.tsx
+++ b/src/AppProvider.tsx
@@ -123,9 +123,19 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
                     }
                     break;
                   }
+                  case "covers": {
+                    collisionTokens.push(tokenTiedToCause);
+                    if (!cause.isCollided) {
+                      return [false, cause.operator];
+                    } else if (cause.isCollided) {
+                      return [true, cause.operator];
+                    }
+                    break;
+                  }
                   case "collision": {
                     if (!cause.isCollided) {
                       collisionTokens.push(tokenTiedToCause);
+                      return [false, cause.operator];
                     } else if (cause.isCollided) {
                       return [true, cause.operator];
                     }

--- a/src/components/Causalities.tsx
+++ b/src/components/Causalities.tsx
@@ -41,7 +41,9 @@ export const Causalities = memo(({ height }: CausalitiesProps) => {
           const allEffects =
             instigatorEffects &&
             instigatorEffects.length > 0 &&
-            causes?.some((cause) => cause.trigger === "collision")
+            causes?.some((cause) =>
+              ["collision", "covers"].includes(cause.trigger),
+            )
               ? [...(effects || []), ...instigatorEffects]
               : effects || [];
 
@@ -134,13 +136,15 @@ export const Causalities = memo(({ height }: CausalitiesProps) => {
                   )}
 
                   <>
-                    {causes?.some((cause) => cause.trigger === "collision") && (
+                    {causes?.some((cause) =>
+                      ["collision", "covers"].includes(cause.trigger),
+                    ) && (
                       <div>
                         <img
                           className={styles["causality-triggering-token-icon"]}
                           src={target}
                           alt="Triggering Token Icon"
-                          title="Add an effect on whichever token triggers this collision"
+                          title="Add an effect on whichever token triggers this collision or covering"
                           onClick={() => {
                             return updateCauseTokenData(
                               causality.id,
@@ -227,13 +231,13 @@ export const Causalities = memo(({ height }: CausalitiesProps) => {
         key="emptyDisclaimer"
         layout="position"
         style={{
-          maxWidth: "355px",
+          maxWidth: "270px",
         }}
       >
         <em>
           Drag tokens here from your <strong>token pool</strong> to create a new
-          "Causality", adding them as the "Cause". When a "Cause" condition is
-          met, each associated "Effect" is triggered.
+          "Causality", adding them as "Causes". When all "Cause" conditiona are
+          met for a "Causalitty", its "Effects" are triggered.
         </em>
       </motion.p>
     );

--- a/src/components/CausalityManager.module.css
+++ b/src/components/CausalityManager.module.css
@@ -6,4 +6,6 @@
   padding: 0 0.25rem;
   position: relative;
   left: -261px;
+  top: -2px;
+  pointer-events: none;
 }

--- a/src/components/Cause.tsx
+++ b/src/components/Cause.tsx
@@ -72,10 +72,11 @@ export const Cause = ({ cause, causality, index }: CauseProps) => {
           >
             <option value="">-- Please choose an option --</option>
             <option value="collision">Is Collided Into</option>
+            <option value="covers">Is Covered</option>
             <option value="appears">Appears</option>
             <option value="disappears">Disappears</option>
           </motion.select>
-          {cause.trigger === "collision" && (
+          {["collision", "covers"].includes(cause.trigger) && (
             <div className={styles["collision-edit-area"]}>
               <button
                 className={styles["collision-edit-buttton"]}

--- a/src/components/GlobalEffectDialog.tsx
+++ b/src/components/GlobalEffectDialog.tsx
@@ -19,6 +19,7 @@ export const GlobalEffectDialog = () => {
 
   const causeTriggerTextMap = {
     collision: "is collided into...",
+    covers: "is covered...",
     appears: "appears...",
     disappears: "disappears...",
     default: "does something...",

--- a/src/functions/checkForCollisions.ts
+++ b/src/functions/checkForCollisions.ts
@@ -55,7 +55,40 @@ export const checkForCollisions = async (
             tokenBeingDraggedBB,
             tokenWithCollisionDetection,
           );
-          if (collisionHasOccured && !underway.collisions[cToken.id]) {
+
+          if (!collisionHasOccured && underway.collisions[cToken.id]) {
+            underway.collisions[cToken.id] = false;
+            await OBR.scene.items.updateItems(
+              (item) => {
+                return [cToken.id].includes(item.id);
+              },
+              (items) => {
+                const itemToUpdate = items.find(
+                  (item) => item.id === cToken.id,
+                ) as CausalityToken;
+                const itemMetaData = itemToUpdate.metadata[ID];
+                const causalities = itemMetaData.causalities;
+                if (causalities && causalities.length > 0) {
+                  for (const causality of causalities) {
+                    const causes = (causality.causes || []).sort((a, b) =>
+                      new Date(a.timestamp) < new Date(b.timestamp) ? 1 : -1,
+                    );
+                    for (const cause of causes) {
+                      if (cause) {
+                        if (
+                          cause.isCollided === true &&
+                          cause.trigger === "covers"
+                        ) {
+                          console.log("MOVED OFF!");
+                          cause.isCollided = false;
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+            );
+          } else if (collisionHasOccured && !underway.collisions[cToken.id]) {
             underway.collisions[cToken.id] = true;
             await OBR.scene.items.updateItems(
               (item) => {
@@ -83,6 +116,7 @@ export const checkForCollisions = async (
                             return;
                           }
                           // Successful Collision!
+                          console.log("MOVED ON!");
                           cause.isCollided = true;
                           const instigatorEffects = causes[0].instigatorEffects;
                           if (

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,12 @@ import { ID } from "../constants";
 
 export type Role = "GM" | "PLAYER" | undefined;
 
-export type CauseTrigger = "collision" | "appears" | "disappears" | "";
+export type CauseTrigger =
+  | "collision"
+  | "covers"
+  | "appears"
+  | "disappears"
+  | "";
 export type EffectAction =
   | "lock"
   | "unlock"


### PR DESCRIPTION
This PR:

- Adds a "Cover" style of collision, where the token has to stay over the token it's colliding with, in order for the causality to trigger.